### PR TITLE
Use vector.reserve() instead of resize()

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -155,16 +155,14 @@ void benchmark_t::load() noexcept
 void benchmark_t::run() noexcept
 {
     std::vector<stats_t> global_stats;
-    global_stats.resize(100000); // Avoid overhead of allocation and page fault
-    global_stats.resize(0);
+    global_stats.reserve(100000); // Avoid overhead of allocation and page fault
 
     static thread_local char value_out[value_generator_t::VALUE_MAX];
     char* values_out;
 
     std::vector<stats_t> local_stats(opt_.num_threads);
     for(auto& lc : local_stats) {
-        lc.times.resize(std::ceil(opt_.num_ops/opt_.num_threads)*2);
-        lc.times.resize(0);
+        lc.times.reserve(std::ceil(opt_.num_ops/opt_.num_threads)*2);
     }
 
     // Control variable of monitor thread


### PR DESCRIPTION
Based on the comments it seems like the intention was to call `reserve()`. While resize to 0 does not decrease `capacity()` (and therefore no memory is de-allocated), the constructor and destructor for each element is still called. Since the struct also contains a vector the overhead of constructing and destructing is compounded.