### PR TITLE
Signed to unsigned implicit conversion causes overflow in latency sampling

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -195,7 +195,7 @@ void benchmark_t::run() noexcept
             {
                 std::this_thread::sleep_for(sampling_window);
                 stats_t s;
-                s.operation_count = std::accumulate(local_stats.begin(), local_stats.end(), 0,
+                s.operation_count = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
                                                     [](uint64_t sum, const stats_t& curr) {
                                                         return sum + curr.operation_count;
                                                     });


### PR DESCRIPTION
Undefined behaviour sanitizer error:
`runtime error: implicit conversion from type 'int' of value -2147031364 (32-bit, signed) to type 'uint64_t' (aka 'unsigned long') changed the value to 18446744071562520252 (64-bit, unsigned)`

The prototype of `std::accumulate` is:
```c++
template< class InputIt, class T, class BinaryOperation >
T accumulate( InputIt first, InputIt last, T init,
              BinaryOperation op );
```
and the type T is deduced from the parameter `init` which is 0 aka signed int. The `op` lambda can return a value larger than 2147483647 which is implicitly converted back to the `init` type as a negative value. The next application of `op` is given a negative signed int as the `sum` which is implicitly converted to a very large 64bit number.