### PR TITLE
Time-based benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ Usage:
   -d, --remove_ratio arg  Ratio of remove operations (default: 0)
   -s, --scan_ratio arg    Ratio of scan operations (default: 0)
       --scan_size arg     Number of records to be scanned. (default: 100)
-      --false_access(T/F) Flag for generating unrepeated keys
+      --false_access(T/F) Flag for generating unrepeated keys (default:false)
       --sampling_ms arg   Sampling window in milliseconds (default: 1000)
       --distribution arg  Key distribution to use (default: UNIFORM)
       --skew arg          Key distribution skew factor to use (default: 0.2)
       --seed arg          Seed for random generators (default: 1729)
-      --mode arg(T/F)     Time based or Operation based mode (default:operation based)
+      --mode arg          Time based or Operation based mode (default:operation)
       --time arg          Benchmark run time under time based mode
       --pcm               Turn on Intel PCM (default: true)
       --pool_path arg     Path to persistent pool (default: )

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Usage:
       --distribution arg  Key distribution to use (default: UNIFORM)
       --skew arg          Key distribution skew factor to use (default: 0.2)
       --seed arg          Seed for random generators (default: 1729)
+      --mode arg(T/F)     Time based or Operation based mode (default:operation based)
+      --time arg          Benchmark run time under time based mode
       --pcm               Turn on Intel PCM (default: true)
       --pool_path arg     Path to persistent pool (default: )
       --pool_size arg     Size of persistent pool (in Bytes) (default: 0)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Usage:
   -d, --remove_ratio arg  Ratio of remove operations (default: 0)
   -s, --scan_ratio arg    Ratio of scan operations (default: 0)
       --scan_size arg     Number of records to be scanned. (default: 100)
-      --false_access(T/F) Flag for generating unrepeated keys (default:false)
+      --negative_access(T/F)  Flag for generating unrepeated keys (default:false)
       --sampling_ms arg   Sampling window in milliseconds (default: 1000)
       --distribution arg  Key distribution to use (default: UNIFORM)
       --skew arg          Key distribution skew factor to use (default: 0.2)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Usage:
   -d, --remove_ratio arg  Ratio of remove operations (default: 0)
   -s, --scan_ratio arg    Ratio of scan operations (default: 0)
       --scan_size arg     Number of records to be scanned. (default: 100)
+      --false_access(T/F) Flag for generating unrepeated keys
       --sampling_ms arg   Sampling window in milliseconds (default: 1000)
       --distribution arg  Key distribution to use (default: UNIFORM)
       --skew arg          Key distribution skew factor to use (default: 0.2)

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -123,12 +123,14 @@ struct options_t
 struct alignas(64) stats_t
 {
     stats_t()
-        : operation_count(0)
+        : operation_count(0),
+        operation_count_F(0)
     {
     }
 
     /// Number of operations completed.
     uint64_t operation_count;
+    uint64_t operation_count_F;
 
     /// Vector to store both start and end time of requests.
     std::vector<std::chrono::high_resolution_clock::time_point> times;
@@ -178,7 +180,7 @@ private:
     * @param value_out Pointer to store Read value
     * @param values_out Pointer to store SCAN value
     */
-    void run_op(operation_t operation, const char * key_ptr, char * value_out, char * values_out);
+    bool run_op(operation_t operation, const char * key_ptr, char * value_out, char * values_out);
 
     /// Tree data structure being benchmarked.
     tree_api* tree_;

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -114,6 +114,7 @@ struct options_t
 
     /// Generate keys which are not in the index structure (used in negative read/update)
     bool negative_access = false;
+    float negative_access_rate = 0.2;
 };
 
 /**

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -94,6 +94,12 @@ struct options_t
 
     /// Ratio of requests to sample latency from (between 0.0 and 1.0).
     float latency_sampling = 0.0;
+
+    /// Benchmark time for time-based benchmark
+    float time = 0.0;
+
+    /// Mode(FALSE:time based or TRUE:operation based)
+    bool bm_mode = true;
 };
 
 /**

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -112,8 +112,8 @@ struct options_t
     /// Mode(FALSE:time based or TRUE:operation based)
     mode_t bm_mode = mode_t::Operation;
 
-    /// Generate keys which are not in the index structure (used in false read/update)
-    bool false_access = false;
+    /// Generate keys which are not in the index structure (used in negative read/update)
+    bool negative_access = false;
 };
 
 /**

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -19,6 +19,17 @@ namespace PiBench
 void print_environment();
 
 /**
+ * @brief Benchmark mode
+ */
+enum class mode_t : uint8_t
+{
+    Operation = 0,
+    Time = 1,
+};
+
+
+
+/**
  * @brief Supported random number distributions.
  *
  */
@@ -99,7 +110,7 @@ struct options_t
     float time = 0.0;
 
     /// Mode(FALSE:time based or TRUE:operation based)
-    bool bm_mode = true;
+    mode_t bm_mode = mode_t::Operation;
 
     /// Generate keys which are not in the index structure (used in false read/update)
     bool false_access = false;

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -159,6 +159,16 @@ public:
     static constexpr size_t MAX_SCAN = 1000;
 
 private:
+    /**
+    * @brief Run single operation
+    *
+    * @param operation operation type
+    * @param key_ptr Pointer to the generated key
+    * @param value_out Pointer to store Read value
+    * @param values_out Pointer to store SCAN value
+    */
+    void run_op(operation_t operation, const char * key_ptr, char * value_out, char * values_out);
+
     /// Tree data structure being benchmarked.
     tree_api* tree_;
 

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -100,6 +100,9 @@ struct options_t
 
     /// Mode(FALSE:time based or TRUE:operation based)
     bool bm_mode = true;
+
+    /// Generate keys which are not in the index structure (used in false read/update)
+    bool false_access = false;
 };
 
 /**

--- a/include/key_generator.hpp
+++ b/include/key_generator.hpp
@@ -115,7 +115,7 @@ public:
     static thread_local uint64_t current_id_;
 
     /// Storing the number of inserts with different thread ID (used as current ID)
-    std::vector<uint64_t> thread_stat;
+    uint64_t* thread_stat;
 
 protected:
     virtual uint64_t next_id() = 0;

--- a/include/key_generator.hpp
+++ b/include/key_generator.hpp
@@ -58,7 +58,7 @@ public:
      *                    if @false keys are generated randomly.
      * @return const char* pointer to beginning of key.
      */
-    virtual const char* next(bool in_sequence = false) final;
+    virtual const char* next(bool negative_access, bool in_sequence = false) final;
 
     /**
      * @brief Generate next key in time based mode
@@ -73,10 +73,10 @@ public:
      * @param in_sequence if @true, keys are generated in sequence,
      *                    if @false keys are generated randomly.
      * @param tid is thread id, which acted as a prefix of the key
-     * @param counter is used in generating different range of random number in runtime
+     * @param negative_access is used to generate id without range
      * @return const char* pointer to beginning of key.
      */
-    virtual const char* next(uint8_t tid, uint64_t counter, bool in_sequence = false) final;
+    virtual const char* next(uint8_t tid, bool negative_access, bool in_sequence = false) final;
 
     /**
      * @brief Returns total key size (including prefix and tid(time-based mode)).
@@ -126,7 +126,7 @@ protected:
 
 private:
     /// Format generated ID
-    void bits_shift(char *buf_ptr, uint64_t hashed_id);
+    void bits_shift(char *buf_ptr, uint64_t id);
 
     /// Seed used for generating random numbers.
     static thread_local uint32_t seed_;

--- a/include/key_generator.hpp
+++ b/include/key_generator.hpp
@@ -122,6 +122,9 @@ protected:
     static thread_local std::default_random_engine generator_;
 
 private:
+    /// Format generated ID
+    void bits_shift(char *buf_ptr, uint64_t hashed_id);
+
     /// Seed used for generating random numbers.
     static thread_local uint32_t seed_;
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -164,7 +164,7 @@ void benchmark_t::load() noexcept
     for (uint64_t i = 0; i < opt_.num_records; ++i)
     {
         // Generate key in sequence
-        auto key_ptr = opt_.bm_mode == mode_t::Operation ? key_generator_->next(true) : key_generator_->next(tid_generate(i,opt_.num_threads), 0, true);
+        auto key_ptr = opt_.bm_mode == mode_t::Operation ? key_generator_->next(false, true) : key_generator_->next(tid_generate(i,opt_.num_threads), false, true);
 
         // Generate random value
         auto value_ptr = value_generator_.next();

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -494,7 +494,7 @@ bool benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value
         case operation_t::READ:
         {
             r = tree_->find(key_ptr, key_generator_->size(), value_out);
-            //assert(r);
+            assert(r);
             break;
         }
 
@@ -503,7 +503,7 @@ bool benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value
             // Generate random value
             auto value_ptr = value_generator_.next();
             r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-            //assert(r);
+            assert(r);
             break;
         }
 
@@ -512,21 +512,21 @@ bool benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value
             // Generate random value
             auto value_ptr = value_generator_.next();
             r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-            //assert(r);
+            assert(r);
             break;
         }
 
         case operation_t::REMOVE:
         {
             r = tree_->remove(key_ptr, key_generator_->size());
-            //assert(r);
+            assert(r);
             break;
         }
 
         case operation_t::SCAN:
         {
             r = static_cast<bool>(tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out));
-            //assert(r);
+            assert(r);
             break;
         }
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -518,6 +518,7 @@ bool benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value
 
         case operation_t::REMOVE:
         {
+            // TODO: Randomly deleting keys will cause false read,update and scan
             r = tree_->remove(key_ptr, key_generator_->size());
             assert(r);
             break;

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -11,7 +11,7 @@
 #include <fstream>
 #include <regex>            // std::regex_replace
 #include <sys/utsname.h>    // uname
-#include <atomic>
+#include <atomic> // std::atomic<T>
 
 namespace PiBench
 {
@@ -181,7 +181,7 @@ void benchmark_t::run() noexcept
     float elapsed = 0.0;
 
     // Start Benchmark
-    // Opration based mode
+    // Operation based mode
     if(opt_.bm_mode)
     {
 
@@ -193,8 +193,6 @@ void benchmark_t::run() noexcept
             lc.times.resize(std::ceil(opt_.num_ops/opt_.num_threads)*2);
             lc.times.resize(0);
         }
-
-
 
         // The amount of inserts expected to be done by each thread + some play room.
         uint64_t inserts_per_thread = 10 + (opt_.num_ops * opt_.insert_ratio) / opt_.num_threads;
@@ -323,7 +321,6 @@ void benchmark_t::run() noexcept
         }
         omp_set_nested(false);
 
-
     }
     // Time based mode
     else
@@ -365,7 +362,7 @@ void benchmark_t::run() noexcept
                 while (!finished.load())
                 {
                     std::this_thread::sleep_for(sampling_window);
-                    if(stopwatch.elapsed<std::chrono::milliseconds>() > opt_.time * 1000)
+                    if(stopwatch.elapsed<std::chrono::seconds>() > opt_.time)
                     {
                         finished.store(true);
                         elapsed = stopwatch.elapsed<std::chrono::milliseconds>();
@@ -427,7 +424,7 @@ void benchmark_t::run() noexcept
                             case operation_t::READ:
                             {
                                 auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 
@@ -436,7 +433,7 @@ void benchmark_t::run() noexcept
                                 // Generate random value
                                 auto value_ptr = value_generator_.next();
                                 auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 
@@ -445,21 +442,21 @@ void benchmark_t::run() noexcept
                                 // Generate random value
                                 auto value_ptr = value_generator_.next();
                                 auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 
                             case operation_t::REMOVE:
                             {
                                 auto r = tree_->remove(key_ptr, key_generator_->size());
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 
                             case operation_t::SCAN:
                             {
                                 auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -256,52 +256,7 @@ void benchmark_t::run() noexcept
                             local_stats[tid].times.push_back(std::chrono::high_resolution_clock::now());
                         }
 
-                        switch (op)
-                        {
-                            case operation_t::READ:
-                            {
-                                auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::INSERT:
-                            {
-                                // Generate random value
-                                auto value_ptr = value_generator_.next();
-                                auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::UPDATE:
-                            {
-                                // Generate random value
-                                auto value_ptr = value_generator_.next();
-                                auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::REMOVE:
-                            {
-                                auto r = tree_->remove(key_ptr, key_generator_->size());
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::SCAN:
-                            {
-                                auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
-                                assert(r);
-                                break;
-                            }
-
-                            default:
-                                std::cout << "Error: unknown operation!" << std::endl;
-                                exit(0);
-                                break;
-                        }
+                        run_op(op,key_ptr,value_out,values_out);
 
                         if(measure_latency)
                         {
@@ -419,52 +374,7 @@ void benchmark_t::run() noexcept
                             local_stats[tid].times.push_back(std::chrono::high_resolution_clock::now());
                         }
 
-                        switch (op)
-                        {
-                            case operation_t::READ:
-                            {
-                                auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::INSERT:
-                            {
-                                // Generate random value
-                                auto value_ptr = value_generator_.next();
-                                auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::UPDATE:
-                            {
-                                // Generate random value
-                                auto value_ptr = value_generator_.next();
-                                auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::REMOVE:
-                            {
-                                auto r = tree_->remove(key_ptr, key_generator_->size());
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::SCAN:
-                            {
-                                auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
-                                assert(r);
-                                break;
-                            }
-
-                            default:
-                                std::cout << "Error: unknown operation!" << std::endl;
-                                exit(0);
-                                break;
-                        }
+                        run_op(op,key_ptr,value_out,values_out);
 
                         if(measure_latency)
                         {
@@ -546,6 +456,60 @@ void benchmark_t::run() noexcept
                   << "\tmax: " << global_latencies[observed-1] << std::endl;
     }
 }
+
+void benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value_out, char *values_out)
+{
+
+    //std::cout << key_ptr << std::endl;
+
+    switch (operation)
+    {
+        case operation_t::READ:
+        {
+            auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
+            //assert(r);
+            break;
+        }
+
+        case operation_t::INSERT:
+        {
+            // Generate random value
+            auto value_ptr = value_generator_.next();
+            auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+            //assert(r);
+            break;
+        }
+
+        case operation_t::UPDATE:
+        {
+            // Generate random value
+            auto value_ptr = value_generator_.next();
+            auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+            //assert(r);
+            break;
+        }
+
+        case operation_t::REMOVE:
+        {
+            auto r = tree_->remove(key_ptr, key_generator_->size());
+            //assert(r);
+            break;
+        }
+
+        case operation_t::SCAN:
+        {
+            auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
+            //assert(r);
+            break;
+        }
+
+        default:
+            std::cout << "Error: unknown operation!" << std::endl;
+            exit(0);
+            break;
+    }
+}
+
 } // namespace PiBench
 
 namespace std
@@ -574,7 +538,7 @@ std::ostream& operator<<(std::ostream& os, const PiBench::options_t& opt)
        << "\n"
        << "\tTarget: " << opt.library_file << "\n"
        << "\t# Records: " << opt.num_records << "\n"
-       << (opt.bm_mode ? "\t# Operations:" : "\t# Running time:") << (opt.bm_mode ? opt.num_ops : opt.time) << "\n"
+       << (opt.bm_mode ? "\t# Operations: " : "\t# Running time: ") << (opt.bm_mode ? opt.num_ops : opt.time) << "\n"
        << "\t# Threads: " << opt.num_threads << "\n"
        << "\tSampling: " << opt.sampling_ms << " ms\n"
        << "\tLatency: " << opt.latency_sampling << "\n"

--- a/src/key_generator.cpp
+++ b/src/key_generator.cpp
@@ -9,11 +9,12 @@ thread_local uint32_t key_generator_t::seed_;
 thread_local char key_generator_t::buf_[KEY_MAX];
 thread_local uint64_t key_generator_t::current_id_ = 1;
 
-key_generator_t::key_generator_t(size_t N, size_t size, bool benchmark_mode, const std::string& prefix)
+key_generator_t::key_generator_t(size_t N, size_t size, uint16_t thread_num, bool tid_prefix, const std::string& prefix)
     : N_(N),
       size_(size),
       prefix_(prefix),
-      benchmark_mode(benchmark_mode)
+      tid_prefix(tid_prefix),
+      thread_stat(thread_num,1)
 {
     memset(buf_, 0, KEY_MAX);
     memcpy(buf_, prefix_.c_str(), prefix_.size());
@@ -38,7 +39,8 @@ const char* key_generator_t::next(uint8_t tid, uint64_t counter, bool in_sequenc
     memcpy(ptr,&tid,1);
     ptr = &buf_[prefix_.size()+1];
 
-    uint64_t id = in_sequence ? current_id_++ : next_id(counter);
+
+    uint64_t id = in_sequence ? thread_stat[tid]++ : next_id(counter);
     uint64_t hashed_id = utils::multiplicative_hash<uint64_t>(id);
 
     bits_shift(ptr,hashed_id);

--- a/src/key_generator.cpp
+++ b/src/key_generator.cpp
@@ -13,9 +13,13 @@ key_generator_t::key_generator_t(size_t N, size_t size, uint16_t thread_num, boo
     : N_(N),
       size_(size),
       prefix_(prefix),
-      tid_prefix(tid_prefix),
-      thread_stat(thread_num,1)
+      tid_prefix(tid_prefix)
 {
+    thread_stat = new uint64_t [thread_num]();
+    for(int i=0; i<thread_num; i++)
+    {
+        thread_stat[i] = 1;
+    }
     memset(buf_, 0, KEY_MAX);
     memcpy(buf_, prefix_.c_str(), prefix_.size());
 }

--- a/src/key_generator.cpp
+++ b/src/key_generator.cpp
@@ -9,10 +9,11 @@ thread_local uint32_t key_generator_t::seed_;
 thread_local char key_generator_t::buf_[KEY_MAX];
 thread_local uint64_t key_generator_t::current_id_ = 1;
 
-key_generator_t::key_generator_t(size_t N, size_t size, const std::string& prefix)
+key_generator_t::key_generator_t(size_t N, size_t size, bool benchmark_mode, const std::string& prefix)
     : N_(N),
       size_(size),
-      prefix_(prefix)
+      prefix_(prefix),
+      benchmark_mode(benchmark_mode)
 {
     memset(buf_, 0, KEY_MAX);
     memcpy(buf_, prefix_.c_str(), prefix_.size());
@@ -23,6 +24,50 @@ const char* key_generator_t::next(bool in_sequence)
     char* ptr = &buf_[prefix_.size()];
 
     uint64_t id = in_sequence ? current_id_++ : next_id();
+    uint64_t hashed_id = utils::multiplicative_hash<uint64_t>(id);
+
+    if (size_ < sizeof(hashed_id))
+    {
+        // We want key smaller than 8 Bytes, so discard higher bits.
+        auto bits_to_shift = (sizeof(hashed_id) - size_) << 3;
+
+        // Discard high order bits
+        if (utils::is_big_endian())
+        {
+            hashed_id >>= bits_to_shift;
+            hashed_id <<= bits_to_shift;
+        }
+        else
+        {
+            hashed_id <<= bits_to_shift;
+            hashed_id >>= bits_to_shift;
+        }
+
+        memcpy(ptr, &hashed_id, size_); // TODO: check if must change to fit endianess
+    }
+    else
+    {
+        // TODO: change this, otherwise zeroes act as prefix
+        // We want key of at least 8 Bytes, check if we must prepend zeroes
+        auto bytes_to_prepend = size_ - sizeof(hashed_id);
+        if (bytes_to_prepend > 0)
+        {
+            memset(ptr, 0, bytes_to_prepend);
+            ptr += bytes_to_prepend;
+        }
+        memcpy(ptr, &hashed_id, sizeof(hashed_id));
+    }
+    return buf_;
+}
+
+const char* key_generator_t::next(uint8_t tid, uint64_t counter, bool in_sequence)
+{
+    // 1 Byte after prefix is tid
+    char *ptr = &buf_[prefix_.size()];
+    memcpy(ptr,&tid,1);
+    ptr = &buf_[prefix_.size()+1];
+
+    uint64_t id = in_sequence ? current_id_++ : next_id(counter);
     uint64_t hashed_id = utils::multiplicative_hash<uint64_t>(id);
 
     if (size_ < sizeof(hashed_id))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char** argv)
             ("s,scan_ratio", "Ratio of scan operations", cxxopts::value<float>()->default_value(std::to_string(opt.scan_ratio)))
             ("scan_size", "Number of records to be scanned.", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.scan_size)))
             ("negative_access","Generate keys not in the index",cxxopts::value<bool>()->default_value((opt.negative_access ? "true" : "false")))
+            ("negative_access_rate"," Ratio of negative read/update operations",cxxopts::value<float>()->default_value(std::to_string(opt.negative_access_rate)))
             ("sampling_ms", "Sampling window in milliseconds", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.sampling_ms)))
             ("distribution", "Key distribution to use", cxxopts::value<std::string>()->default_value("UNIFORM"))
             ("skew", "Key distribution skew factor to use", cxxopts::value<float>()->default_value(std::to_string(opt.key_skew)))
@@ -198,11 +199,17 @@ int main(int argc, char** argv)
         if (result.count("time"))
             opt.time = result["time"].as<float>();
 
+        //Parse "negative_access_rate"
+        if(result.count("negative_access_rate"))
+            opt.negative_access_rate = result["negative_access_rate"].as<float>();
+
         //Parse "negative_access"
         if(result.count("negative_access"))
+        {
             opt.negative_access = result["negative_access"].as<bool>();
-
-
+            if(!opt.negative_access)
+                opt.negative_access_rate = 0.0;
+        }
     }
     catch (const cxxopts::OptionException& e)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ int main(int argc, char** argv)
             ("d,remove_ratio", "Ratio of remove operations", cxxopts::value<float>()->default_value(std::to_string(opt.remove_ratio)))
             ("s,scan_ratio", "Ratio of scan operations", cxxopts::value<float>()->default_value(std::to_string(opt.scan_ratio)))
             ("scan_size", "Number of records to be scanned.", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.scan_size)))
+            ("false_access","Generate keys not in the index",cxxopts::value<bool>()->default_value((opt.false_access ? "true":"false")))
             ("sampling_ms", "Sampling window in milliseconds", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.sampling_ms)))
             ("distribution", "Key distribution to use", cxxopts::value<std::string>()->default_value("UNIFORM"))
             ("skew", "Key distribution skew factor to use", cxxopts::value<float>()->default_value(std::to_string(opt.key_skew)))
@@ -47,7 +48,7 @@ int main(int argc, char** argv)
             ("pool_size", "Size of persistent pool (in Bytes)", cxxopts::value<uint64_t>()->default_value(std::to_string(tree_opt.pool_size)))
             ("skip_load", "Skip the load phase", cxxopts::value<bool>()->default_value((opt.skip_load ? "true" : "false")))
             ("latency_sampling", "Sample latency of requests", cxxopts::value<float>()->default_value(std::to_string(opt.latency_sampling)))
-            ("m,mode","Benchmark mode",cxxopts::value<bool>()->default_value((opt.bm_mode ? "true":"false")))
+            ("mode","Benchmark mode",cxxopts::value<bool>()->default_value((opt.bm_mode ? "true":"false")))
             ("time","Time PiBench run in time-based mode",cxxopts::value<float>()->default_value(std::to_string(opt.time)))
             ("help", "Print help")
         ;
@@ -185,6 +186,10 @@ int main(int argc, char** argv)
         if (result.count("time"))
             opt.time = result["time"].as<float>();
 
+        //Parse "false_access"
+        if(result.count("false_access"))
+            opt.false_access = result["false_access"].as<bool>();
+
 
     }
     catch (const cxxopts::OptionException& e)
@@ -217,6 +222,12 @@ int main(int argc, char** argv)
         if(opt.num_threads > 256)
         {
             std::cout << "In time-based mode, thread number must be less than 256." <<std::endl;
+            exit(1);
+        }
+
+        if(opt.time <= 0.0)
+        {
+            std::cout << "Benchmark running time must be larger than 0." <<std::endl;
             exit(1);
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv)
             ("d,remove_ratio", "Ratio of remove operations", cxxopts::value<float>()->default_value(std::to_string(opt.remove_ratio)))
             ("s,scan_ratio", "Ratio of scan operations", cxxopts::value<float>()->default_value(std::to_string(opt.scan_ratio)))
             ("scan_size", "Number of records to be scanned.", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.scan_size)))
-            ("false_access","Generate keys not in the index",cxxopts::value<bool>()->default_value((opt.false_access ? "true":"false")))
+            ("negative_access","Generate keys not in the index",cxxopts::value<bool>()->default_value((opt.negative_access ? "true" : "false")))
             ("sampling_ms", "Sampling window in milliseconds", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.sampling_ms)))
             ("distribution", "Key distribution to use", cxxopts::value<std::string>()->default_value("UNIFORM"))
             ("skew", "Key distribution skew factor to use", cxxopts::value<float>()->default_value(std::to_string(opt.key_skew)))
@@ -198,9 +198,9 @@ int main(int argc, char** argv)
         if (result.count("time"))
             opt.time = result["time"].as<float>();
 
-        //Parse "false_access"
-        if(result.count("false_access"))
-            opt.false_access = result["false_access"].as<bool>();
+        //Parse "negative_access"
+        if(result.count("negative_access"))
+            opt.negative_access = result["negative_access"].as<bool>();
 
 
     }


### PR DESCRIPTION
I'm adding a time-based benchmark mode. Users can specify the time PiBench runs.
--mode command is for choosing the mode
--time for specifying the running time
--false_access for generating unrepeated keys(to emulate false read and update)
