### PR TITLE
Key space division

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,12 @@ Usage:
   -d, --remove_ratio arg  Ratio of remove operations (default: 0)
   -s, --scan_ratio arg    Ratio of scan operations (default: 0)
       --scan_size arg     Number of records to be scanned. (default: 100)
-      --negative_access(T/F)  Flag for generating unrepeated keys (default:false)
       --sampling_ms arg   Sampling window in milliseconds (default: 1000)
       --distribution arg  Key distribution to use (default: UNIFORM)
       --skew arg          Key distribution skew factor to use (default: 0.2)
       --seed arg          Seed for random generators (default: 1729)
-      --mode arg          Time based or Operation based mode (default:operation)
-      --time arg          Benchmark run time under time based mode
+      --mode arg          Time based or operation based mode (default:operation)
+      --seconds arg       Benchmark duration in seconds under the time-based mode
       --pcm               Turn on Intel PCM (default: true)
       --pool_path arg     Path to persistent pool (default: )
       --pool_size arg     Size of persistent pool (in Bytes) (default: 0)

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ Usage:
   -d, --remove_ratio arg  Ratio of remove operations (default: 0)
   -s, --scan_ratio arg    Ratio of scan operations (default: 0)
       --scan_size arg     Number of records to be scanned. (default: 100)
-      --false_access(T/F) Flag for generating unrepeated keys
+      --false_access(T/F) Flag for generating unrepeated keys (default:false)
       --sampling_ms arg   Sampling window in milliseconds (default: 1000)
       --distribution arg  Key distribution to use (default: UNIFORM)
       --skew arg          Key distribution skew factor to use (default: 0.2)
       --seed arg          Seed for random generators (default: 1729)
-      --mode arg(T/F)     Time based or Operation based mode (default:operation based)
+      --mode arg          Time based or Operation based mode (default:operation)
       --time arg          Benchmark run time under time based mode
       --pcm               Turn on Intel PCM (default: true)
       --pool_path arg     Path to persistent pool (default: )

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Usage:
       --distribution arg  Key distribution to use (default: UNIFORM)
       --skew arg          Key distribution skew factor to use (default: 0.2)
       --seed arg          Seed for random generators (default: 1729)
+      --mode arg(T/F)     Time based or Operation based mode (default:operation based)
+      --time arg          Benchmark run time under time based mode
       --pcm               Turn on Intel PCM (default: true)
       --pool_path arg     Path to persistent pool (default: )
       --pool_size arg     Size of persistent pool (in Bytes) (default: 0)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Find out more about PiBench and results in our [VLDB paper](http://www.vldb.org/
 Lucas Lersch, Xiangpeng Hao, Ismail Oukid, Tianzheng Wang, Thomas Willhalm:
 Evaluating Persistent Memory Range Indexes. PVLDB 13(4): 574-587 (2019)
 ````
+Check out [**PiBench Online**](http://pibench.org) for an online demo of PiBench! Code is available [here](https://github.com/sfu-dis/pibench-online) to deploy your own.
 
 # Building
 The project comprises an executable binary that dynamically links to a shared library implementing a persistent data structure.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Usage:
   -d, --remove_ratio arg  Ratio of remove operations (default: 0)
   -s, --scan_ratio arg    Ratio of scan operations (default: 0)
       --scan_size arg     Number of records to be scanned. (default: 100)
-      --false_access(T/F) Flag for generating unrepeated keys (default:false)
+      --negative_access(T/F)  Flag for generating unrepeated keys (default:false)
       --sampling_ms arg   Sampling window in milliseconds (default: 1000)
       --distribution arg  Key distribution to use (default: UNIFORM)
       --skew arg          Key distribution skew factor to use (default: 0.2)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Usage:
   -d, --remove_ratio arg  Ratio of remove operations (default: 0)
   -s, --scan_ratio arg    Ratio of scan operations (default: 0)
       --scan_size arg     Number of records to be scanned. (default: 100)
+      --false_access(T/F) Flag for generating unrepeated keys
       --sampling_ms arg   Sampling window in milliseconds (default: 1000)
       --distribution arg  Key distribution to use (default: UNIFORM)
       --skew arg          Key distribution skew factor to use (default: 0.2)

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -123,12 +123,14 @@ struct options_t
 struct alignas(64) stats_t
 {
     stats_t()
-        : operation_count(0)
+        : operation_count(0),
+        operation_count_F(0)
     {
     }
 
     /// Number of operations completed.
     uint64_t operation_count;
+    uint64_t operation_count_F;
 
     /// Vector to store both start and end time of requests.
     std::vector<std::chrono::high_resolution_clock::time_point> times;
@@ -178,7 +180,7 @@ private:
     * @param value_out Pointer to store Read value
     * @param values_out Pointer to store SCAN value
     */
-    void run_op(operation_t operation, const char * key_ptr, char * value_out, char * values_out);
+    bool run_op(operation_t operation, const char * key_ptr, char * value_out, char * values_out);
 
     /// Tree data structure being benchmarked.
     tree_api* tree_;

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -114,6 +114,7 @@ struct options_t
 
     /// Generate keys which are not in the index structure (used in negative read/update)
     bool negative_access = false;
+    float negative_access_rate = 0.2;
 };
 
 /**

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -16,197 +16,220 @@
 namespace PiBench
 {
 
-void print_environment();
+    void print_environment();
 
 /**
  * @brief Benchmark mode
  */
-enum class mode_t : uint8_t
-{
-    Operation = 0,
-    Time = 1,
-};
-
-
+    enum class mode_t : uint8_t
+    {
+        Operation = 0,
+        Time = 1,
+    };
 
 /**
  * @brief Supported random number distributions.
  *
  */
-enum class distribution_t : uint8_t
-{
-    UNIFORM = 0,
-    SELFSIMILAR = 1,
-    ZIPFIAN = 2
-};
+    enum class distribution_t : uint8_t
+    {
+        UNIFORM = 0,
+        SELFSIMILAR = 1,
+        ZIPFIAN = 2
+    };
 
 /**
  * @brief Benchmark options.
  *
  */
-struct options_t
-{
-    /// Name of tree library file used to run the benchmark against.
-    std::string library_file = "";
+    struct options_t
+    {
+        /// Name of tree library file used to run the benchmark against.
+        std::string library_file = "";
 
-    /// Number of records to insert into tree during 'load' phase.
-    uint64_t num_records = 1e6;
+        /// Number of records to insert into tree during 'load' phase.
+        uint64_t num_records = 1e6;
 
-    /// Number of operations to issue during 'run' phase.
-    uint64_t num_ops = 1e6;
+        /// Number of operations to issue during 'run' phase.
+        uint64_t num_ops = 1e6;
 
-    /// Number of parallel threads used for executing requests.
-    uint32_t num_threads = 1;
+        /// Number of parallel threads used for executing requests.
+        uint32_t num_threads = 1;
 
-    /// Sampling window in milliseconds.
-    uint32_t sampling_ms = 1000;
+        /// Sampling window in milliseconds.
+        uint32_t sampling_ms = 1000;
 
-    /// Key prefix.
-    std::string key_prefix = "";
+        /// Key prefix.
+        std::string key_prefix = "";
 
-    /// Size of key in bytes.
-    uint32_t key_size = 8;
+        /// Size of key in bytes.
+        uint32_t key_size = 8;
 
-    /// Size of value in bytes.
-    uint32_t value_size = 8;
+        /// Size of value in bytes.
+        uint32_t value_size = 8;
 
-    /// Ratio of read operations.
-    float read_ratio = 1.0;
+        /// Ratio of read operations.
+        float read_ratio = 1.0;
 
-    /// Ratio of insert operations.
-    float insert_ratio = 0.0;
+        /// Ratio of insert operations.
+        float insert_ratio = 0.0;
 
-    /// Ratio of update operations.
-    float update_ratio = 0.0;
+        /// Ratio of update operations.
+        float update_ratio = 0.0;
 
-    /// Ratio of remove operations.
-    float remove_ratio = 0.0;
+        /// Ratio of remove operations.
+        float remove_ratio = 0.0;
 
-    /// Ratio of scan operations.
-    float scan_ratio = 0.0;
+        /// Ratio of scan operations.
+        float scan_ratio = 0.0;
 
-    /// Size of scan operations in records.
-    uint32_t scan_size = 100;
+        /// Size of scan operations in records.
+        uint32_t scan_size = 100;
 
-    /// Distribution used for generation random keys.
-    distribution_t key_distribution = distribution_t::UNIFORM;
+        /// Distribution used for generation random keys.
+        distribution_t key_distribution = distribution_t::UNIFORM;
 
-    /// Factor to be used for skewed random key distributions.
-    float key_skew = 0.2;
+        /// Factor to be used for skewed random key distributions.
+        float key_skew = 0.2;
 
-    /// Master seed to be used for random generations.
-    uint32_t rnd_seed = 1729;
+        /// Master seed to be used for random generations.
+        uint32_t rnd_seed = 1729;
 
-    /// Whether to enable Intel PCM for profiling.
-    bool enable_pcm = true;
+        /// Whether to enable Intel PCM for profiling.
+        bool enable_pcm = true;
 
-    /// Whether to skip the load phase.
-    bool skip_load = false;
+        /// Whether to skip the load phase.
+        bool skip_load = false;
 
-    /// Ratio of requests to sample latency from (between 0.0 and 1.0).
-    float latency_sampling = 0.0;
+        /// Ratio of requests to sample latency from (between 0.0 and 1.0).
+        float latency_sampling = 0.0;
 
-    /// Benchmark time for time-based benchmark
-    float time = 0.0;
+        /// Experiment duration (seconds) for time-based benchmark
+        uint32_t seconds = 20;
 
-    /// Mode(FALSE:time based or TRUE:operation based)
-    mode_t bm_mode = mode_t::Operation;
-
-    /// Generate keys which are not in the index structure (used in negative read/update)
-    bool negative_access = false;
-    float negative_access_rate = 0.2;
-};
+        /// Experiment mode
+        mode_t bm_mode = mode_t::Operation;
+    };
 
 /**
  * @brief Statistics collected over time.
  *
  */
-struct alignas(64) stats_t
-{
-    stats_t()
-        : operation_count(0),
-        operation_count_F(0)
+    struct alignas(64) stats_t
     {
-    }
+        stats_t()
+                : operation_count(0)
+                , insert_count(0)
+                , success_insert_count(0)
+                , read_count(0)
+                , success_read_count(0)
+                , update_count(0)
+                , success_update_count(0)
+                , remove_count(0)
+                , success_remove_count(0)
+                , scan_count(0)
+                , success_scan_count(0)
+        {
+        }
 
-    /// Number of operations completed.
-    uint64_t operation_count;
-    uint64_t operation_count_F;
+        /// Number of operations completed.
+        uint64_t operation_count;
 
-    /// Vector to store both start and end time of requests.
-    std::vector<std::chrono::high_resolution_clock::time_point> times;
+        /// Number of inserts completed
+        uint64_t insert_count;
 
-    /// Padding to enforce cache-line size and avoid cache-line ping-pong.
-    uint64_t ____padding[7];
-};
+        /// Number of successful inserts
+        uint64_t success_insert_count;
 
-class benchmark_t
-{
-public:
-    /**
-     * @brief Construct a new benchmark_t object.
-     *
-     * @param tree pointer to tree data structure compliant with the API.
-     * @param opt options used to run the benchmark.
-     */
-    benchmark_t(tree_api* tree, const options_t& opt) noexcept;
+        /// Number of reads completed
+        uint64_t read_count;
 
-    /**
-     * @brief Destroy the benchmark_t object.
-     *
-     */
-    ~benchmark_t();
+        /// Number of successful point reads
+        uint64_t success_read_count;
 
-    /**
-     * @brief Load the tree with the amount of records specified in options_t.
-     *
-     * A single thread is used for load phase to guarantee determinism across
-     * multiple runs. Using multiple threads can lead to different, but
-     * equivalent, results.
-     */
-    void load() noexcept;
+        /// Number of updates completed
+        uint64_t update_count;
 
-    /// Run the workload as specified by options_t.
-    void run() noexcept;
+        /// Number of successful point reads
+        uint64_t success_update_count;
 
-    /// Maximum number of records to be scanned.
-    static constexpr size_t MAX_SCAN = 1000;
+        /// Number of remove completed
+        uint64_t remove_count;
 
-private:
-    /**
-    * @brief Run single operation
-    *
-    * @param operation operation type
-    * @param key_ptr Pointer to the generated key
-    * @param value_out Pointer to store Read value
-    * @param values_out Pointer to store SCAN value
-    */
-    bool run_op(operation_t operation, const char * key_ptr, char * value_out, char * values_out);
+        /// Number of successful point reads
+        uint64_t success_remove_count;
 
-    /// Tree data structure being benchmarked.
-    tree_api* tree_;
+        /// Number of scan completed
+        uint64_t scan_count;
 
-    /// Options used to run this benchmark.
-    const options_t opt_;
+        /// Number of successful point reads
+        uint64_t success_scan_count;
 
-    /// Operation generator.
-    operation_generator_t op_generator_;
+        /// Vector to store both start and end time of requests.
+        std::vector<std::chrono::high_resolution_clock::time_point> times;
+    };
 
-    /// Key generator.
-    std::unique_ptr<key_generator_t> key_generator_;
+    class benchmark_t
+    {
+    public:
+        /**
+         * @brief Construct a new benchmark_t object.
+         *
+         * @param tree pointer to tree data structure compliant with the API.
+         * @param opt options used to run the benchmark.
+         */
+        benchmark_t(tree_api* tree, const options_t& opt) noexcept;
 
-    /// Value generator.
-    value_generator_t value_generator_;
+        /**
+         * @brief Destroy the benchmark_t object.
+         *
+         */
+        ~benchmark_t();
 
-    /// Intel PCM handler.
-    PCM* pcm_;
-};
+        /**
+         * @brief Load the tree with the amount of records specified in options_t.
+         *
+         * A single thread is used for load phase to guarantee determinism across
+         * multiple runs. Using multiple threads can lead to different, but
+         * equivalent, results.
+         */
+        void load() noexcept;
+
+        /// Run the workload as specified by options_t.
+        void run() noexcept;
+
+        /// Maximum number of records to be scanned.
+        static constexpr size_t MAX_SCAN = 1000;
+
+    private:
+        void run_op(operation_t op, const char *key_ptr,
+                    char *value_out, char *values_out, bool measure_latency,
+                    stats_t &stats);
+
+        /// Tree data structure being benchmarked.
+        tree_api* tree_;
+
+        /// Options used to run this benchmark.
+        const options_t opt_;
+
+        /// Operation generator.
+        operation_generator_t op_generator_;
+
+        /// Key generator.
+        std::unique_ptr<key_generator_t> key_generator_;
+
+        /// Value generator.
+        value_generator_t value_generator_;
+
+        /// Intel PCM handler.
+        PCM* pcm_;
+    };
 } // namespace PiBench
 
 namespace std
 {
-std::ostream& operator<<(std::ostream& os, const PiBench::distribution_t& dist);
-std::ostream& operator<<(std::ostream& os, const PiBench::options_t& opt);
+    std::ostream& operator<<(std::ostream& os, const PiBench::distribution_t& dist);
+    std::ostream& operator<<(std::ostream& os, const PiBench::options_t& opt);
 } // namespace std
 
 #endif

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -94,6 +94,12 @@ struct options_t
 
     /// Ratio of requests to sample latency from (between 0.0 and 1.0).
     float latency_sampling = 0.0;
+
+    /// Benchmark time for time-based benchmark
+    float time = 0.0;
+
+    /// Mode(FALSE:time based or TRUE:operation based)
+    bool bm_mode = true;
 };
 
 /**

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -112,8 +112,8 @@ struct options_t
     /// Mode(FALSE:time based or TRUE:operation based)
     mode_t bm_mode = mode_t::Operation;
 
-    /// Generate keys which are not in the index structure (used in false read/update)
-    bool false_access = false;
+    /// Generate keys which are not in the index structure (used in negative read/update)
+    bool negative_access = false;
 };
 
 /**

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -19,6 +19,17 @@ namespace PiBench
 void print_environment();
 
 /**
+ * @brief Benchmark mode
+ */
+enum class mode_t : uint8_t
+{
+    Operation = 0,
+    Time = 1,
+};
+
+
+
+/**
  * @brief Supported random number distributions.
  *
  */
@@ -99,7 +110,7 @@ struct options_t
     float time = 0.0;
 
     /// Mode(FALSE:time based or TRUE:operation based)
-    bool bm_mode = true;
+    mode_t bm_mode = mode_t::Operation;
 
     /// Generate keys which are not in the index structure (used in false read/update)
     bool false_access = false;

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -159,6 +159,16 @@ public:
     static constexpr size_t MAX_SCAN = 1000;
 
 private:
+    /**
+    * @brief Run single operation
+    *
+    * @param operation operation type
+    * @param key_ptr Pointer to the generated key
+    * @param value_out Pointer to store Read value
+    * @param values_out Pointer to store SCAN value
+    */
+    void run_op(operation_t operation, const char * key_ptr, char * value_out, char * values_out);
+
     /// Tree data structure being benchmarked.
     tree_api* tree_;
 

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -223,9 +223,6 @@ private:
 
     /// Intel PCM handler.
     PCM* pcm_;
-
-    // Array storing the start ID for each thread
-    uint64_t * cur_id_start;
 };
 } // namespace PiBench
 

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -203,7 +203,7 @@ public:
 
 private:
     void run_op(operation_t op, const char *key_ptr, 
-                char *value_out, char *values_out, bool measure_latency,
+                char *value_out, char *values_out,
                 stats_t &stats);
 
     /// Tree data structure being benchmarked.
@@ -223,6 +223,9 @@ private:
 
     /// Intel PCM handler.
     PCM* pcm_;
+
+    // Array storing the start ID for each thread
+    uint64_t * cur_id_start;
 };
 } // namespace PiBench
 

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -100,6 +100,9 @@ struct options_t
 
     /// Mode(FALSE:time based or TRUE:operation based)
     bool bm_mode = true;
+
+    /// Generate keys which are not in the index structure (used in false read/update)
+    bool false_access = false;
 };
 
 /**

--- a/include/key_generator.hpp
+++ b/include/key_generator.hpp
@@ -115,7 +115,7 @@ public:
     static thread_local uint64_t current_id_;
 
     /// Storing the number of inserts with different thread ID (used as current ID)
-    std::vector<uint64_t> thread_stat;
+    uint64_t* thread_stat;
 
 protected:
     virtual uint64_t next_id() = 0;

--- a/include/key_generator.hpp
+++ b/include/key_generator.hpp
@@ -58,7 +58,7 @@ public:
      *                    if @false keys are generated randomly.
      * @return const char* pointer to beginning of key.
      */
-    virtual const char* next(bool in_sequence = false) final;
+    virtual const char* next(bool negative_access, bool in_sequence = false) final;
 
     /**
      * @brief Generate next key in time based mode
@@ -73,10 +73,10 @@ public:
      * @param in_sequence if @true, keys are generated in sequence,
      *                    if @false keys are generated randomly.
      * @param tid is thread id, which acted as a prefix of the key
-     * @param counter is used in generating different range of random number in runtime
+     * @param negative_access is used to generate id without range
      * @return const char* pointer to beginning of key.
      */
-    virtual const char* next(uint8_t tid, uint64_t counter, bool in_sequence = false) final;
+    virtual const char* next(uint8_t tid, bool negative_access, bool in_sequence = false) final;
 
     /**
      * @brief Returns total key size (including prefix and tid(time-based mode)).
@@ -126,7 +126,7 @@ protected:
 
 private:
     /// Format generated ID
-    void bits_shift(char *buf_ptr, uint64_t hashed_id);
+    void bits_shift(char *buf_ptr, uint64_t id);
 
     /// Seed used for generating random numbers.
     static thread_local uint32_t seed_;

--- a/include/key_generator.hpp
+++ b/include/key_generator.hpp
@@ -19,8 +19,7 @@ namespace PiBench
  *
  * The generated keys are composed of two parts:
  * |----- prefix (optional) -----||---- id -----|
- * if time-based, the keys are in three parts
- * |----- prefix (optional) -----||---- tid ----||---- id -----|
+ *
  * The generated 'ids' are 8 Byte unsigned integers. The 'ids' are then hashed
  * to scramble the keys across the keyspace.
  *
@@ -29,199 +28,151 @@ namespace PiBench
  * preppended to match the size.
  *
  */
-class key_generator_t
-{
-public:
-    /**
-     * @brief Construct a new key_generator_t object
-     *
-     * @param N size of key space.
-     * @param size size in Bytes of keys to be generated (excluding prefix).
-     * @param benchmark_mode PiBench's running mode(operation based / time based)
-     * @param prefix prefix to be prepended to every key.
-     */
-    key_generator_t(size_t N, size_t size, uint16_t thread_num, bool tid_prefix, const std::string& prefix = "");
-
-    virtual ~key_generator_t() = default;
-
-    /**
-     * @brief Generate next key in op mode.
-     *
-     * Setting 'in_sequence' to true is useful when initially loading the data
-     * structure, so no repeated keys are generated and we can guarantee the
-     * amount of unique records inserted.
-     *
-     * Finally, a pointer to buf_ is returned. Since next() overwrites buf_, the
-     * pointer returned should not be used across calls to next().
-     *
-     * @param in_sequence if @true, keys are generated in sequence,
-     *                    if @false keys are generated randomly.
-     * @return const char* pointer to beginning of key.
-     */
-    virtual const char* next(bool negative_access, bool in_sequence = false) final;
-
-    /**
-     * @brief Generate next key in time based mode
-     *
-     * Setting 'in_sequence' to true is useful when initially loading the data
-     * structure, so no repeated keys are generated and we can guarantee the
-     * amount of unique records inserted.
-     *
-     * Finally, a pointer to buf_ is returned. Since next() overwrites buf_, the
-     * pointer returned should not be used across calls to next().
-     *
-     * @param in_sequence if @true, keys are generated in sequence,
-     *                    if @false keys are generated randomly.
-     * @param tid is thread id, which acted as a prefix of the key
-     * @param negative_access is used to generate id without range
-     * @return const char* pointer to beginning of key.
-     */
-    virtual const char* next(uint8_t tid, bool negative_access, bool in_sequence = false) final;
-
-    /**
-     * @brief Returns total key size (including prefix and tid(time-based mode)).
-     *
-     * @return size_t
-     */
-    size_t size() const noexcept { return tid_prefix ? prefix_.size() + size_ + 1 : prefix_.size() + size_ ; }
-
-    /**
-     * @brief Returns size of keyspace in number of elements..
-     *
-     * @return size_t
-     */
-    size_t keyspace() const noexcept { return N_; }
-
-    /**
-     * @brief Set the seed object.
-     *
-     * @param seed
-     */
-    static void set_seed(uint32_t seed)
+    class key_generator_t
     {
-        seed_ = seed;
-        generator_.seed(seed_);
-    }
+    public:
+        /**
+         * @brief Construct a new key_generator_t object
+         *
+         * @param N size of key space.
+         * @param size size in Bytes of keys to be generated (excluding prefix).
+         * @param prefix prefix to be prepended to every key.
+         */
+        key_generator_t(size_t N, size_t size, const std::string& prefix = "");
 
-    /**
-     * @brief Get the seed object.
-     *
-     * @return uint32_t
-     */
-    static uint32_t get_seed() noexcept { return seed_; }
+        virtual ~key_generator_t() = default;
 
-    static constexpr uint32_t KEY_MAX = 128;
+        /**
+         * @brief Generate next key.
+         *
+         * Setting 'in_sequence' to true is useful when initially loading the data
+         * structure, so no repeated keys are generated and we can guarantee the
+         * amount of unique records inserted.
+         *
+         * Finally, a pointer to buf_ is returned. Since next() overwrites buf_, the
+         * pointer returned should not be used across calls to next().
+         *
+         * @param in_sequence if @true, keys are generated in sequence,
+         *                    if @false keys are generated randomly.
+         * @return const char* pointer to beginning of key.
+         */
+        virtual const char* next(bool in_sequence = false) final;
 
-    static thread_local uint64_t current_id_;
+        /**
+         * @brief Returns total key size (including prefix).
+         *
+         * @return size_t
+         */
+        size_t size() const noexcept { return prefix_.size() + size_; }
 
-    /// Storing the number of inserts with different thread ID (used as current ID)
-    uint64_t* thread_stat;
+        /**
+         * @brief Returns size of keyspace in number of elements..
+         *
+         * @return size_t
+         */
+        size_t keyspace() const noexcept { return N_; }
 
-protected:
-    virtual uint64_t next_id() = 0;
-    virtual uint64_t next_id(uint64_t upper_bound) = 0;
+        /**
+         * @brief Set the seed object.
+         *
+         * @param seed
+         */
+        static void set_seed(uint32_t seed)
+        {
+            seed_ = seed;
+            generator_.seed(seed_);
+        }
 
-    /// Engine used for generating random numbers.
-    static thread_local std::default_random_engine generator_;
+        /**
+         * @brief Get the seed object.
+         *
+         * @return uint32_t
+         */
+        static uint32_t get_seed() noexcept { return seed_; }
 
-private:
-    /// Format generated ID
-    void bits_shift(char *buf_ptr, uint64_t id);
+        static constexpr uint32_t KEY_MAX = 128;
 
-    /// Seed used for generating random numbers.
-    static thread_local uint32_t seed_;
+        static thread_local uint64_t current_id_;
 
-    /// Space to materialize the keys (avoid allocation).
-    static thread_local char buf_[KEY_MAX];
+        const char* hash_id(uint64_t id);
 
-    /// Size of keyspace to generate keys.
-    const size_t N_;
+        virtual uint64_t next_id() = 0;
 
-    /// Size in Bytes of keys to be generated (excluding prefix).
-    const size_t size_;
+    protected:
 
-    /// Prefix to be preppended to every key.
-    const std::string prefix_;
+        /// Engine used for generating random numbers.
+        static thread_local std::default_random_engine generator_;
 
-    //uint64_t current_id_ = 0;
+    private:
+        /// Seed used for generating random numbers.
+        static thread_local uint32_t seed_;
 
-    /// Flag: whether tid become a part of the prefix
-    bool tid_prefix;
+        /// Space to materialize the keys (avoid allocation).
+        static thread_local char buf_[KEY_MAX];
 
-};
+        /// Size of keyspace to generate keys.
+        const size_t N_;
 
-class uniform_key_generator_t final : public key_generator_t
-{
-public:
-    uniform_key_generator_t(size_t N, size_t size, uint16_t thread_num, bool tid_prefix, const std::string& prefix = "")
-        : dist_(1, N),
-          key_generator_t(N, size, thread_num, tid_prefix, prefix) {}
+        /// Size in Bytes of keys to be generated (excluding prefix).
+        const size_t size_;
 
-protected:
-    virtual uint64_t next_id() override
+        /// Prefix to be preppended to every key.
+        const std::string prefix_;
+
+        //uint64_t current_id_ = 0;
+    };
+
+    class uniform_key_generator_t final : public key_generator_t
     {
-        return dist_(generator_);
-    }
+    public:
+        uniform_key_generator_t(size_t N, size_t size, const std::string& prefix = "")
+                : dist_(1, N),
+                  key_generator_t(N, size, prefix) {}
 
-    virtual uint64_t next_id(uint64_t upper_bound) override
+    protected:
+        virtual uint64_t next_id() override
+        {
+            return dist_(generator_);
+        }
+
+    private:
+        std::uniform_int_distribution<uint64_t> dist_;
+    };
+
+    class selfsimilar_key_generator_t final : public key_generator_t
     {
-        std::uniform_int_distribution<uint64_t> tmp_dist(1,upper_bound);
-        return tmp_dist(generator_);
-    }
+    public:
+        selfsimilar_key_generator_t(size_t N, size_t size, const std::string& prefix = "", float skew = 0.2)
+                : dist_(1, N, skew),
+                  key_generator_t(N, size, prefix)
+        {
+        }
 
-private:
-    std::uniform_int_distribution<uint64_t> dist_;
-};
+        virtual uint64_t next_id() override
+        {
+            return dist_(generator_);
+        }
 
-class selfsimilar_key_generator_t final : public key_generator_t
-{
-public:
-    selfsimilar_key_generator_t(size_t N, size_t size, uint16_t thread_num, bool tid_prefix, const std::string& prefix = "", float skew = 0.2)
-        : dist_(1, N, skew),
-          key_generator_t(N, size, thread_num, tid_prefix, prefix),
-          skew_(skew)
+    private:
+        selfsimilar_int_distribution<uint64_t> dist_;
+    };
+
+    class zipfian_key_generator_t final : public key_generator_t
     {
-    }
+    public:
+        zipfian_key_generator_t(size_t N, size_t size, const std::string& prefix = "", float skew = 0.99)
+                : dist_(1, N, skew),
+                  key_generator_t(N, size, prefix)
+        {
+        }
 
-    virtual uint64_t next_id() override
-    {
-        return dist_(generator_);
-    }
+        virtual uint64_t next_id() override
+        {
+            return dist_(generator_);
+        }
 
-    virtual uint64_t next_id(uint64_t upper_bound) override
-    {
-        selfsimilar_int_distribution<uint64_t> tmp_dist(1,upper_bound,skew_);
-        return tmp_dist(generator_);
-    }
-
-private:
-    selfsimilar_int_distribution<uint64_t> dist_;
-    float skew_;
-};
-
-class zipfian_key_generator_t final : public key_generator_t
-{
-public:
-    zipfian_key_generator_t(size_t N, size_t size, uint16_t thread_num, bool tid_prefix, const std::string& prefix = "", float skew = 0.99)
-        : dist_(1, N, skew),
-          key_generator_t(N, size, thread_num, tid_prefix, prefix),
-          skew_(skew)
-    {
-    }
-
-    virtual uint64_t next_id() override
-    {
-        return dist_(generator_);
-    }
-
-    virtual uint64_t next_id(uint64_t upper_bound) override
-    {
-        zipfian_int_distribution<uint64_t> tmp_dist(1,upper_bound,skew_);
-        return tmp_dist(generator_);
-    }
-private:
-    zipfian_int_distribution<uint64_t> dist_;
-    float skew_;
-};
+    private:
+        zipfian_int_distribution<uint64_t> dist_;
+    };
 } // namespace PiBench
 #endif

--- a/include/key_generator.hpp
+++ b/include/key_generator.hpp
@@ -98,6 +98,9 @@ public:
 
     virtual uint64_t next_id() = 0;
 
+    // Generate an ID within the range [a,b]
+    virtual uint64_t next_id(uint64_t a, uint64_t b) = 0;
+
 protected:
 
     /// Engine used for generating random numbers.
@@ -135,6 +138,12 @@ protected:
         return dist_(generator_);
     }
 
+    virtual uint64_t next_id(uint64_t a, uint64_t b) override
+    {
+        std::uniform_int_distribution<uint64_t> dis(a,b);
+        return dis(generator_);
+    }
+
 private:
     std::uniform_int_distribution<uint64_t> dist_;
 };
@@ -153,6 +162,12 @@ public:
         return dist_(generator_);
     }
 
+    virtual uint64_t next_id(uint64_t a, uint64_t b) override
+    {
+        selfsimilar_int_distribution<uint64_t> dis(a,b);
+        return dis(generator_);
+    }
+
 private:
     selfsimilar_int_distribution<uint64_t> dist_;
 };
@@ -169,6 +184,12 @@ public:
     virtual uint64_t next_id() override
     {
         return dist_(generator_);
+    }
+
+    virtual uint64_t next_id(uint64_t a, uint64_t b) override
+    {
+        zipfian_int_distribution<uint64_t> dis(a,b);
+        return dis(generator_);
     }
 
 private:

--- a/include/key_generator.hpp
+++ b/include/key_generator.hpp
@@ -122,6 +122,9 @@ protected:
     static thread_local std::default_random_engine generator_;
 
 private:
+    /// Format generated ID
+    void bits_shift(char *buf_ptr, uint64_t hashed_id);
+
     /// Seed used for generating random numbers.
     static thread_local uint32_t seed_;
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -164,7 +164,7 @@ void benchmark_t::load() noexcept
     for (uint64_t i = 0; i < opt_.num_records; ++i)
     {
         // Generate key in sequence
-        auto key_ptr = opt_.bm_mode == mode_t::Operation ? key_generator_->next(true) : key_generator_->next(tid_generate(i,opt_.num_threads), 0, true);
+        auto key_ptr = opt_.bm_mode == mode_t::Operation ? key_generator_->next(false, true) : key_generator_->next(tid_generate(i,opt_.num_threads), false, true);
 
         // Generate random value
         auto value_ptr = value_generator_.next();

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -494,7 +494,7 @@ bool benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value
         case operation_t::READ:
         {
             r = tree_->find(key_ptr, key_generator_->size(), value_out);
-            //assert(r);
+            assert(r);
             break;
         }
 
@@ -503,7 +503,7 @@ bool benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value
             // Generate random value
             auto value_ptr = value_generator_.next();
             r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-            //assert(r);
+            assert(r);
             break;
         }
 
@@ -512,21 +512,21 @@ bool benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value
             // Generate random value
             auto value_ptr = value_generator_.next();
             r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-            //assert(r);
+            assert(r);
             break;
         }
 
         case operation_t::REMOVE:
         {
             r = tree_->remove(key_ptr, key_generator_->size());
-            //assert(r);
+            assert(r);
             break;
         }
 
         case operation_t::SCAN:
         {
             r = static_cast<bool>(tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out));
-            //assert(r);
+            assert(r);
             break;
         }
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -518,6 +518,7 @@ bool benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value
 
         case operation_t::REMOVE:
         {
+            // TODO: Randomly deleting keys will cause false read,update and scan
             r = tree_->remove(key_ptr, key_generator_->size());
             assert(r);
             break;

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -11,7 +11,7 @@
 #include <fstream>
 #include <regex>            // std::regex_replace
 #include <sys/utsname.h>    // uname
-#include <atomic>
+#include <atomic> // std::atomic<T>
 
 namespace PiBench
 {
@@ -181,7 +181,7 @@ void benchmark_t::run() noexcept
     float elapsed = 0.0;
 
     // Start Benchmark
-    // Opration based mode
+    // Operation based mode
     if(opt_.bm_mode)
     {
 
@@ -193,8 +193,6 @@ void benchmark_t::run() noexcept
             lc.times.resize(std::ceil(opt_.num_ops/opt_.num_threads)*2);
             lc.times.resize(0);
         }
-
-
 
         // The amount of inserts expected to be done by each thread + some play room.
         uint64_t inserts_per_thread = 10 + (opt_.num_ops * opt_.insert_ratio) / opt_.num_threads;
@@ -323,7 +321,6 @@ void benchmark_t::run() noexcept
         }
         omp_set_nested(false);
 
-
     }
     // Time based mode
     else
@@ -365,7 +362,7 @@ void benchmark_t::run() noexcept
                 while (!finished.load())
                 {
                     std::this_thread::sleep_for(sampling_window);
-                    if(stopwatch.elapsed<std::chrono::milliseconds>() > opt_.time * 1000)
+                    if(stopwatch.elapsed<std::chrono::seconds>() > opt_.time)
                     {
                         finished.store(true);
                         elapsed = stopwatch.elapsed<std::chrono::milliseconds>();
@@ -427,7 +424,7 @@ void benchmark_t::run() noexcept
                             case operation_t::READ:
                             {
                                 auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 
@@ -436,7 +433,7 @@ void benchmark_t::run() noexcept
                                 // Generate random value
                                 auto value_ptr = value_generator_.next();
                                 auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 
@@ -445,21 +442,21 @@ void benchmark_t::run() noexcept
                                 // Generate random value
                                 auto value_ptr = value_generator_.next();
                                 auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 
                             case operation_t::REMOVE:
                             {
                                 auto r = tree_->remove(key_ptr, key_generator_->size());
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 
                             case operation_t::SCAN:
                             {
                                 auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
-                                //assert(r);
+                                assert(r);
                                 break;
                             }
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -11,228 +11,208 @@
 #include <fstream>
 #include <regex>            // std::regex_replace
 #include <sys/utsname.h>    // uname
-#include <atomic> // std::atomic<T>
 
 namespace PiBench
 {
 
-void print_environment()
-{
-    std::time_t now = std::time(nullptr);
-    uint64_t num_cpus = 0;
-    std::string cpu_type;
-    std::string cache_size;
-
-    std::ifstream cpuinfo("/proc/cpuinfo", std::ifstream::in);
-
-    if(!cpuinfo.good())
+    void print_environment()
     {
-        num_cpus = 0;
-        cpu_type = "Could not open /proc/cpuinfo";
-        cache_size = "Could not open /proc/cpuinfo";
-    }
-    else
-    {
-        std::string line;
-        while(!getline(cpuinfo, line).eof())
+        std::time_t now = std::time(nullptr);
+        uint64_t num_cpus = 0;
+        std::string cpu_type;
+        std::string cache_size;
+
+        std::ifstream cpuinfo("/proc/cpuinfo", std::ifstream::in);
+
+        if(!cpuinfo.good())
         {
-            auto sep_pos = line.find(':');
-            if(sep_pos == std::string::npos)
+            num_cpus = 0;
+            cpu_type = "Could not open /proc/cpuinfo";
+            cache_size = "Could not open /proc/cpuinfo";
+        }
+        else
+        {
+            std::string line;
+            while(!getline(cpuinfo, line).eof())
             {
-                continue;
-            }
-            else
-            {
-                std::string key = std::regex_replace(std::string(line, 0, sep_pos), std::regex("\\t+$"), "");
-                std::string val = sep_pos == line.size()-1 ? "" : std::string(line, sep_pos+2, line.size());
-                if(key.compare("model name") == 0)
+                auto sep_pos = line.find(':');
+                if(sep_pos == std::string::npos)
                 {
-                    ++num_cpus;
-                    cpu_type = val;
+                    continue;
                 }
-                else if(key.compare("cache size") == 0)
+                else
                 {
-                    cache_size = val;
+                    std::string key = std::regex_replace(std::string(line, 0, sep_pos), std::regex("\\t+$"), "");
+                    std::string val = sep_pos == line.size()-1 ? "" : std::string(line, sep_pos+2, line.size());
+                    if(key.compare("model name") == 0)
+                    {
+                        ++num_cpus;
+                        cpu_type = val;
+                    }
+                    else if(key.compare("cache size") == 0)
+                    {
+                        cache_size = val;
+                    }
                 }
             }
         }
-    }
-    cpuinfo.close();
+        cpuinfo.close();
 
-    std::string kernel_version;
-    struct utsname uname_buf;
-    if(uname(&uname_buf) == -1)
-    {
-        kernel_version = "Unknown";
-    }
-    else
-    {
-        kernel_version = std::string(uname_buf.sysname) + " " + std::string(uname_buf.release);
-    }
-
-    std::cout << "Environment:" << "\n"
-              << "\tTime: " << std::asctime(std::localtime(&now))
-              << "\tCPU: " << num_cpus << " * " << cpu_type << "\n"
-              << "\tCPU Cache: " << cache_size << "\n"
-              << "\tKernel: " << kernel_version << std::endl;
-}
-
-benchmark_t::benchmark_t(tree_api* tree, const options_t& opt) noexcept
-    : tree_(tree),
-      opt_(opt),
-      op_generator_(opt.read_ratio, opt.insert_ratio, opt.update_ratio, opt.remove_ratio, opt.scan_ratio),
-      value_generator_(opt.value_size),
-      pcm_(nullptr)
-{
-    if (opt.enable_pcm)
-    {
-        pcm_ = PCM::getInstance();
-        auto status = pcm_->program();
-        if (status != PCM::Success)
+        std::string kernel_version;
+        struct utsname uname_buf;
+        if(uname(&uname_buf) == -1)
         {
-            std::cout << "Error opening PCM: " << status << std::endl;
-            if (status == PCM::PMUBusy)
-                pcm_->resetPMU();
-            else
+            kernel_version = "Unknown";
+        }
+        else
+        {
+            kernel_version = std::string(uname_buf.sysname) + " " + std::string(uname_buf.release);
+        }
+
+        std::cout << "Environment:" << "\n"
+                  << "\tTime: " << std::asctime(std::localtime(&now))
+                  << "\tCPU: " << num_cpus << " * " << cpu_type << "\n"
+                  << "\tCPU Cache: " << cache_size << "\n"
+                  << "\tKernel: " << kernel_version << std::endl;
+    }
+
+    benchmark_t::benchmark_t(tree_api* tree, const options_t& opt) noexcept
+            : tree_(tree),
+              opt_(opt),
+              op_generator_(opt.read_ratio, opt.insert_ratio, opt.update_ratio, opt.remove_ratio, opt.scan_ratio),
+              value_generator_(opt.value_size),
+              pcm_(nullptr)
+    {
+        if (opt.enable_pcm)
+        {
+            pcm_ = PCM::getInstance();
+            auto status = pcm_->program();
+            if (status != PCM::Success)
+            {
+                std::cout << "Error opening PCM: " << status << std::endl;
+                if (status == PCM::PMUBusy)
+                    pcm_->resetPMU();
+                else
+                    exit(0);
+            }
+        }
+
+        size_t key_space_sz = opt_.num_records + (opt_.num_ops * opt_.insert_ratio);
+        switch (opt_.key_distribution)
+        {
+            case distribution_t::UNIFORM:
+                key_generator_ = std::make_unique<uniform_key_generator_t>(key_space_sz, opt_.key_size, opt_.key_prefix);
+                break;
+
+            case distribution_t::SELFSIMILAR:
+                key_generator_ = std::make_unique<selfsimilar_key_generator_t>(key_space_sz, opt_.key_size, opt_.key_prefix, opt_.key_skew);
+                break;
+
+            case distribution_t::ZIPFIAN:
+                key_generator_ = std::make_unique<zipfian_key_generator_t>(key_space_sz, opt_.key_size, opt_.key_prefix, opt_.key_skew);
+                break;
+
+            default:
+                std::cout << "Error: unknown distribution!" << std::endl;
                 exit(0);
         }
     }
 
-    size_t key_space_sz = opt_.num_records + (opt_.num_ops * opt_.insert_ratio);
-    switch (opt_.key_distribution)
+    benchmark_t::~benchmark_t()
     {
-        case distribution_t::UNIFORM:
-            key_generator_ = std::make_unique<uniform_key_generator_t>(key_space_sz, opt_.key_size, opt_.num_threads, opt_.bm_mode == mode_t::Operation ? false : true, opt_.key_prefix);
-            break;
-
-        case distribution_t::SELFSIMILAR:
-            key_generator_ = std::make_unique<selfsimilar_key_generator_t>(key_space_sz, opt_.key_size, opt_.num_threads, opt_.bm_mode == mode_t::Operation ? false : true, opt_.key_prefix, opt_.key_skew);
-            break;
-
-        case distribution_t::ZIPFIAN:
-            key_generator_ = std::make_unique<zipfian_key_generator_t>(key_space_sz, opt_.key_size, opt_.num_threads, opt_.bm_mode == mode_t::Operation ? false : true, opt_.key_prefix, opt_.key_skew);
-            break;
-
-        default:
-            std::cout << "Error: unknown distribution!" << std::endl;
-            exit(0);
+        if (pcm_)
+            pcm_->cleanup();
     }
-}
 
-benchmark_t::~benchmark_t()
-{
-    if (pcm_)
-        pcm_->cleanup();
-}
-
-void benchmark_t::load() noexcept
-{
-    uint64_t insert_per_thread = opt_.num_records / opt_.num_threads;
-
-    if(opt_.skip_load)
+    void benchmark_t::load() noexcept
     {
-        if(opt_.bm_mode == mode_t::Operation)
+        if(opt_.skip_load)
         {
+            std::cout << "Load skipped." << std::endl;
             key_generator_->current_id_ = opt_.num_records + 1;
+            return;
         }
-        else if(opt_.bm_mode == mode_t::Time)
+
+        std::cout << "Loading started." << std::endl;
+        stopwatch_t sw;
+        sw.start();
+
         {
-            for(uint16_t i =0; i <opt_.num_threads; i++)
+#pragma omp parallel num_threads(opt_.num_threads)
             {
-                if(i!=opt_.num_threads-1)
-                    key_generator_->thread_stat[i] = insert_per_thread + 1;
-                else
-                    key_generator_->thread_stat[i] = opt_.num_records % opt_.num_threads + insert_per_thread + 1;
+                // Initialize insert id for each thread
+                key_generator_->current_id_ = opt_.num_records / opt_.num_threads * omp_get_thread_num();
+
+#pragma omp for schedule(static)
+                for (uint64_t i = 0; i < opt_.num_records; ++i)
+                {
+                    // Generate key in sequence
+                    auto key_ptr = key_generator_->next(true);
+
+                    // Generate random value
+                    auto value_ptr = value_generator_.next();
+
+                    auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                    assert(r);
+                }
+            }
+
+        }
+
+        auto elapsed = sw.elapsed<std::chrono::milliseconds>();
+
+        std::cout << "Loading finished in " << elapsed << " milliseconds" << std::endl;
+
+        // Verify all keys can be found
+        {
+#pragma omp parallel num_threads(opt_.num_threads)
+            {
+                // Initialize insert id for each thread
+                auto id = opt_.num_records / opt_.num_threads * omp_get_thread_num();
+
+#pragma omp for schedule(static)
+                for (uint64_t i = 0; i < opt_.num_records; ++i)
+                {
+                    // Generate key in sequence
+                    auto key_ptr = key_generator_->hash_id(id++);
+
+                    static thread_local char value_out[value_generator_t::VALUE_MAX];
+                    bool found = tree_->find(key_ptr, key_generator_->size(), value_out);
+                    if (!found) {
+                        exit(1);
+                    }
+                }
             }
         }
-        return;
+
+        std::cout << "Load verified; benchmark started." << std::endl;
     }
 
-    /// Generating tid prefix when running time based benchmark
-    auto tid_generate = [insert_per_thread](uint64_t i, uint64_t num_threads){
-        if(i < insert_per_thread * num_threads){
-            return i / insert_per_thread;
-        }
-        else
-        {
-            return num_threads - 1;
-        }
-    };
-
-    stopwatch_t sw;
-    sw.start();
-    for (uint64_t i = 0; i < opt_.num_records; ++i)
+    void benchmark_t::run() noexcept
     {
-        // Generate key in sequence
-        auto key_ptr = opt_.bm_mode == mode_t::Operation ? key_generator_->next(false, true) : key_generator_->next(tid_generate(i,opt_.num_threads), false, true);
+        std::vector<stats_t> global_stats;
+        global_stats.resize(100000); // Avoid overhead of allocation and page fault
+        global_stats.resize(0);
 
-        // Generate random value
-        auto value_ptr = value_generator_.next();
+        static thread_local char value_out[value_generator_t::VALUE_MAX];
+        char* values_out;
 
-        auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-        assert(r);
-    }
-
-    auto elapsed = sw.elapsed<std::chrono::milliseconds>();
-
-    std::cout << "Overview:"
-              << "\n"
-              << "\tLoad time: " << elapsed << " milliseconds" << std::endl;
-}
-
-void benchmark_t::run() noexcept
-{
-    std::vector<stats_t> global_stats;
-
-    std::vector<stats_t> local_stats(opt_.num_threads);
-
-    global_stats.resize(
-            opt_.bm_mode == mode_t::Operation ? 100000 :
-                                                        static_cast<uint64_t>((opt_.time * 1000 / opt_.sampling_ms) + 10)); // Avoid overhead of allocation and page fault
-    global_stats.resize(0);
-
-    if(opt_.bm_mode == mode_t::Operation)
-    {
+        std::vector<stats_t> local_stats(opt_.num_threads);
         for(auto& lc : local_stats)
         {
-            lc.times.resize(std::ceil(opt_.num_ops / opt_.num_threads * 2 ));
+            if (opt_.bm_mode == mode_t::Operation)
+            {
+                lc.times.resize(std::ceil(opt_.num_ops/opt_.num_threads)*2);
+            }
+            else
+            {
+                lc.times.resize(1000000);
+            }
             lc.times.resize(0);
         }
-    }
 
-    else
-    {
-        for(auto& lc : local_stats)
-        {
-            lc.times.resize(std::ceil(static_cast<uint64_t>(100000 * opt_.num_threads *  opt_.time)));
-            lc.times.resize(0);
-        }
-    }
-
-
-    static thread_local char value_out[value_generator_t::VALUE_MAX];
-    char* values_out;
-
-    // Control variable of monitor thread
-    std::atomic<bool> finished(false);
-
-    std::unique_ptr<SystemCounterState> before_sstate;
-    if (opt_.enable_pcm)
-    {
-        before_sstate = std::make_unique<SystemCounterState>();
-        *before_sstate = getSystemCounterState();
-    }
-
-    stopwatch_t stopwatch;
-    float elapsed = 0.0;
-
-    std::discrete_distribution<bool> dis {opt_.negative_access_rate, 1-opt_.negative_access_rate};
-
-    // Start Benchmark
-    // Operation based mode
-    if(opt_.bm_mode == mode_t::Operation)
-    {
-
+        // Control variable of monitor thread
+        bool finished = false;
 
         // The amount of inserts expected to be done by each thread + some play room.
         uint64_t inserts_per_thread = 10 + (opt_.num_ops * opt_.insert_ratio) / opt_.num_threads;
@@ -240,28 +220,53 @@ void benchmark_t::run() noexcept
         // Current id after load
         uint64_t current_id = key_generator_->current_id_;
 
-        omp_set_nested(true);
-        #pragma omp parallel sections num_threads(2)
+        std::unique_ptr<SystemCounterState> before_sstate;
+        if (opt_.enable_pcm)
         {
-            #pragma omp section // Monitor thread
+            before_sstate = std::make_unique<SystemCounterState>();
+            *before_sstate = getSystemCounterState();
+        }
+
+        double elapsed = 0.0;
+        stopwatch_t sw;
+        omp_set_nested(true);
+#pragma omp parallel sections num_threads(2)
+        {
+#pragma omp section // Monitor thread
             {
                 std::chrono::milliseconds sampling_window(opt_.sampling_ms);
-                while (!finished.load())
+                auto sample_stats = [&]()
                 {
                     std::this_thread::sleep_for(sampling_window);
                     stats_t s;
-                    s.operation_count = std::accumulate(local_stats.begin(), local_stats.end(), 0,
+                    s.operation_count = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
                                                         [](uint64_t sum, const stats_t& curr) {
                                                             return sum + curr.operation_count;
                                                         });
                     global_stats.push_back(std::move(s));
+                };
+
+                if (opt_.bm_mode == mode_t::Operation)
+                {
+                    while (!finished)
+                    {
+                        sample_stats();
+                    }
+                }
+                else
+                {
+                    uint32_t slept = 0;
+                    do {
+                        sample_stats();
+                    }
+                    while (++slept < opt_.seconds);
+                    finished = true;
                 }
             }
 
-            #pragma omp section // Worker threads
+#pragma omp section // Worker threads
             {
-
-                #pragma omp parallel num_threads(opt_.num_threads)
+#pragma omp parallel num_threads(opt_.num_threads)
                 {
                     auto tid = omp_get_thread_num();
 
@@ -269,328 +274,349 @@ void benchmark_t::run() noexcept
                     key_generator_->set_seed(opt_.rnd_seed * (tid + 1));
 
                     // Initialize insert id for each thread
-                    // TODO(Yuan Meng) Current way of specifying current_id cannot assure every key generated exists in the index tree
                     key_generator_->current_id_ = current_id + (inserts_per_thread * tid);
 
                     auto random_bool = std::bind(std::bernoulli_distribution(opt_.latency_sampling), std::knuth_b());
 
-                    #pragma omp barrier
+#pragma omp barrier
 
-                    #pragma omp single nowait
+#pragma omp single nowait
                     {
-                        stopwatch.start();
+                        sw.start();
                     }
 
-                    #pragma omp for schedule(static)
-                    for (uint64_t i = 0; i < opt_.num_ops; ++i)
+                    auto execute_op = [&]()
                     {
                         // Generate random operation
                         auto op = op_generator_.next();
 
                         // Generate random scrambled key
-                        auto key_ptr = key_generator_->next( false, op == operation_t::INSERT ? true : false);
+                        const char *key_ptr = nullptr;
+                        if (op == operation_t::INSERT)
+                        {
+                            key_ptr = key_generator_->next(true);
+                        }
+                        else
+                        {
+                            auto id = key_generator_->next_id();
+                            if (opt_.bm_mode == mode_t::Time)
+                            {
+                                // Scale back to insert amount
+                                id %= (local_stats[tid].success_insert_count * opt_.num_threads + opt_.num_records);
+                                if (id >= opt_.num_records) {
+                                    uint64_t ins = id - opt_.num_records;
+                                    id = opt_.num_records + inserts_per_thread * (ins / local_stats[tid].success_insert_count) + ins % local_stats[tid].success_insert_count;
+                                }
+                            }
+                            key_ptr = key_generator_->hash_id(id);
+                        }
 
                         auto measure_latency = random_bool();
-                        if(measure_latency)
+                        if (measure_latency)
                         {
                             local_stats[tid].times.push_back(std::chrono::high_resolution_clock::now());
                         }
 
-                        if(!run_op(op,key_ptr,value_out,values_out))
-                            ++local_stats[tid].operation_count_F;
+                        run_op(op, key_ptr, value_out, values_out, measure_latency, local_stats[tid]);
 
-                        if(measure_latency)
+                        if (measure_latency)
                         {
                             local_stats[tid].times.push_back(std::chrono::high_resolution_clock::now());
                         }
-                        ++local_stats[tid].operation_count;
+                    };
+
+                    if (opt_.bm_mode == mode_t::Operation)
+                    {
+#pragma omp for schedule(static)
+                        for (uint64_t i = 0; i < opt_.num_ops; ++i)
+                        {
+                            execute_op();
+                        }
+                    }
+                    else
+                    {
+                        uint32_t slept = 0;
+                        do
+                        {
+                            execute_op();
+                        }
+                        while (!finished);
                     }
 
                     // Get elapsed time and signal monitor thread to finish.
-                    #pragma omp single nowait
+#pragma omp single nowait
                     {
-                        elapsed = stopwatch.elapsed<std::chrono::milliseconds>();
-                        finished.store(true);
+                        elapsed = sw.elapsed<std::chrono::milliseconds>();
+                        finished = true;
                     }
                 }
             }
         }
         omp_set_nested(false);
 
-    }
-    // Time based mode
-    else
-    {
-
-        omp_set_nested(true);
-        #pragma omp parallel sections num_threads(2) default(none) shared(finished,local_stats,global_stats,elapsed,values_out,std::cout,stopwatch,dis)
+        std::unique_ptr<SystemCounterState> after_sstate;
+        if (opt_.enable_pcm)
         {
-            #pragma omp section // Monitor & timer thread
-            {
-                std::chrono::milliseconds sampling_window(opt_.sampling_ms);
-                while (!finished.load())
-                {
-                    std::this_thread::sleep_for(sampling_window);
-                    stats_t s;
-                    s.operation_count = std::accumulate(local_stats.begin(), local_stats.end(), 0,
+            after_sstate = std::make_unique<SystemCounterState>();
+            *after_sstate = getSystemCounterState();
+        }
+
+        std::cout << std::fixed << std::setprecision(4);
+        std::cout << "\tRun time: " << elapsed << " milliseconds" << std::endl;
+
+        uint64_t total_ops = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                             [](uint64_t sum, const stats_t& curr) {
+                                                 return sum + curr.operation_count;
+                                             });
+
+        uint64_t total_success_ops = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                                     [](uint64_t sum, const stats_t& curr) {
+                                                         return sum + curr.success_insert_count
+                                                                + curr.success_read_count
+                                                                + curr.success_update_count
+                                                                + curr.success_remove_count
+                                                                + curr.success_scan_count;
+                                                     });
+
+        uint64_t total_insert = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                                [](uint64_t sum, const stats_t& curr) {
+                                                    return sum + curr.insert_count;
+                                                });
+
+        uint64_t total_success_insert = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
                                                         [](uint64_t sum, const stats_t& curr) {
-                                                            return sum + curr.operation_count;
+                                                            return sum + curr.success_insert_count;
                                                         });
-                    global_stats.push_back(std::move(s));
-                    if(stopwatch.elapsed<std::chrono::seconds>() > opt_.time)
-                    {
-                        finished.store(true);
-                        elapsed = stopwatch.elapsed<std::chrono::milliseconds>();
-                    }
-                }
-            }
+
+        uint64_t total_read = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                              [](uint64_t sum, const stats_t& curr) {
+                                                  return sum + curr.read_count;
+                                              });
+
+        uint64_t total_success_read = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                                      [](uint64_t sum, const stats_t& curr) {
+                                                          return sum + curr.success_read_count;
+                                                      });
+
+        uint64_t total_update = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                                [](uint64_t sum, const stats_t& curr) {
+                                                    return sum + curr.update_count;
+                                                });
+
+        uint64_t total_success_update = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                                        [](uint64_t sum, const stats_t& curr) {
+                                                            return sum + curr.success_update_count;
+                                                        });
+
+        uint64_t total_remove = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                                [](uint64_t sum, const stats_t& curr) {
+                                                    return sum + curr.remove_count;
+                                                });
+
+        uint64_t total_success_remove = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                                        [](uint64_t sum, const stats_t& curr) {
+                                                            return sum + curr.success_remove_count;
+                                                        });
+
+        uint64_t total_scan = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                              [](uint64_t sum, const stats_t& curr) {
+                                                  return sum + curr.scan_count;
+                                              });
+
+        uint64_t total_success_scan = std::accumulate(local_stats.begin(), local_stats.end(), 0ull,
+                                                      [](uint64_t sum, const stats_t& curr) {
+                                                          return sum + curr.success_scan_count;
+                                                      });
 
 
-            #pragma omp section // Worker threads
+        if (opt_.bm_mode == mode_t::Operation && opt_.num_ops != total_ops)
+        {
+            std::cout << "Fatal: Total operations specified/performed don't match!";
+            exit(1);
+        }
+
+        std::cout << "Results:\n";
+        std::cout << "\tOperations: " << total_ops << std::endl;
+        std::cout << "\tThroughput:\n"
+                  << "\t- Completed: " << total_ops / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Succeeded: " << total_success_ops / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\tBreakdown:\n"
+                  << "\t- Insert completed: " << total_insert / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Insert succeeded: " << total_success_insert / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Read completed: " << total_read / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Read succeeded: " << total_success_read / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Update completed: " << total_update / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Update succeeded: " << total_success_update / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Remove completed: " << total_remove / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Remove succeeded: " << total_success_remove/ ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Scan completed: " << total_scan / ((double)elapsed / 1000) << " ops/s\n"
+                  << "\t- Scan succeeded: " << total_success_scan/ ((double)elapsed / 1000) << " ops/s"
+                  << std::endl;
+
+        if (opt_.enable_pcm)
+        {
+            std::cout << "PCM Metrics:"
+                      << "\n"
+                      << "\tL3 misses: " << getL3CacheMisses(*before_sstate, *after_sstate) << "\n"
+                      << "\tDRAM Reads (bytes): " << getBytesReadFromMC(*before_sstate, *after_sstate) << "\n"
+                      << "\tDRAM Writes (bytes): " << getBytesWrittenToMC(*before_sstate, *after_sstate) << "\n"
+                      << "\tNVM Reads (bytes): " << getBytesReadFromPMM(*before_sstate, *after_sstate) << "\n"
+                      << "\tNVM Writes (bytes): " << getBytesWrittenToPMM(*before_sstate, *after_sstate) << std::endl;
+        }
+
+        std::cout << "Samples:" << std::endl;
+        std::adjacent_difference(global_stats.begin(), global_stats.end(), global_stats.begin(),
+                                 [](const stats_t& x, const stats_t& y) {
+                                     stats_t s;
+                                     s.operation_count = x.operation_count - y.operation_count;
+                                     return s;
+                                 });
+
+        for (auto s : global_stats)
+            std::cout << "\t" << s.operation_count << std::endl;
+
+        if(opt_.latency_sampling > 0.0)
+        {
+            std::vector<uint64_t> global_latencies;
+            for(auto& v : local_stats)
+                for(unsigned int i=0; i<v.times.size(); i=i+2)
+                    global_latencies.push_back(std::chrono::nanoseconds(v.times[i+1]-v.times[i]).count());
+
+            std::sort(global_latencies.begin(), global_latencies.end());
+            auto observed = global_latencies.size();
+            std::cout << "Latencies (" << observed << " operations observed):\n"
+                      << "\tmin: " << global_latencies[0] << '\n'
+                      << "\t50%: " << global_latencies[0.5*observed] << '\n'
+                      << "\t90%: " << global_latencies[0.9*observed] << '\n'
+                      << "\t99%: " << global_latencies[0.99*observed] << '\n'
+                      << "\t99.9%: " << global_latencies[0.999*observed] << '\n'
+                      << "\t99.99%: " << global_latencies[0.9999*observed] << '\n'
+                      << "\t99.999%: " << global_latencies[0.99999*observed] << '\n'
+                      << "\tmax: " << global_latencies[observed-1] << std::endl;
+        }
+    }
+
+    void benchmark_t::run_op(operation_t op, const char *key_ptr,
+                             char *value_out, char *values_out, bool measure_latency,
+                             stats_t &stats)
+    {
+        switch (op)
+        {
+            case operation_t::READ:
             {
-                #pragma omp parallel num_threads(opt_.num_threads) shared(finished)
+                auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
+                ++stats.read_count;
+                if (r)
                 {
-                    auto tid = omp_get_thread_num();
-
-                    key_generator_->set_seed(opt_.rnd_seed * (tid + 1));
-
-                    std::default_random_engine engine(time(0) * (tid+1));
-
-                    // How many inserts are within this thread ID's range
-                    key_generator_->current_id_ = key_generator_->thread_stat[tid];
-
-                    auto random_bool = std::bind(std::bernoulli_distribution(opt_.latency_sampling), std::knuth_b());
-
-                    #pragma omp barrier
-
-                    #pragma single nowait
-                    {
-                        stopwatch.start();
-                    }
-
-                    while(!finished.load())
-                    {
-
-                        // Generate random operation
-                        auto op = op_generator_.next();
-
-                        const char* key_ptr;
-
-                        // Generate random scrambled key
-                        if(op == operation_t::INSERT)
-                            key_ptr = key_generator_->next(tid, false, true);
-                        else if(op == operation_t::READ || op == operation_t::UPDATE)
-                            // Generate some unrepeated key for READ & UPDATE (if negative_access == true)
-                            // TODO: Make sure to generate a negative access key(dividing next() to two parts)
-                        {
-                            if(!opt_.negative_access)
-                                key_ptr = key_generator_->next(tid,false,false);
-                            else
-                                key_ptr = dis(engine) ? key_generator_->next(tid,false,false) : key_generator_->next(tid,true, false);
-                        }
-                        else
-                            key_ptr = key_generator_->next(tid, false, false);
-
-                        auto measure_latency = random_bool();
-
-                        if(measure_latency)
-                        {
-                            local_stats[tid].times.push_back(std::chrono::high_resolution_clock::now());
-                        }
-
-                        if(!run_op(op,key_ptr,value_out,values_out))
-                            ++local_stats[tid].operation_count_F;
-
-                        if(measure_latency)
-                        {
-                            local_stats[tid].times.push_back(std::chrono::high_resolution_clock::now());
-                        }
-                        ++local_stats[tid].operation_count;
-                    }
+                    ++stats.success_read_count;
                 }
-
+                break;
             }
+
+            case operation_t::INSERT:
+            {
+                // Generate random value
+                auto value_ptr = value_generator_.next();
+                auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                ++stats.insert_count;
+                if (r)
+                {
+                    ++stats.success_insert_count;
+                }
+                break;
+            }
+
+            case operation_t::UPDATE:
+            {
+                // Generate random value
+                auto value_ptr = value_generator_.next();
+                auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+                ++stats.update_count;
+                if (r)
+                {
+                    ++stats.success_update_count;
+                }
+                break;
+            }
+
+            case operation_t::REMOVE:
+            {
+                auto r = tree_->remove(key_ptr, key_generator_->size());
+                ++stats.remove_count;
+                if (r)
+                {
+                    ++stats.success_remove_count;
+                }
+                break;
+            }
+
+            case operation_t::SCAN:
+            {
+                auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
+                ++stats.scan_count;
+                if (r)
+                {
+                    ++stats.success_scan_count;
+                }
+                break;
+            }
+
+            default:
+                std::cout << "Error: unknown operation!" << std::endl;
+                exit(0);
+                break;
         }
-        omp_set_nested(false);
+        ++stats.operation_count;
     }
-
-    std::unique_ptr<SystemCounterState> after_sstate;
-    if (opt_.enable_pcm)
-    {
-        after_sstate = std::make_unique<SystemCounterState>();    /// Storing the number of inserts with different thread ID
-        *after_sstate = getSystemCounterState();
-    }
-
-    std::cout << std::fixed << std::setprecision(4);
-    std::cout << "\tRun time: " << elapsed << " milliseconds" << std::endl;
-
-    // False operation number
-    uint64_t op_num_f = 0;
-    for(auto &lc: local_stats)
-        op_num_f+=lc.operation_count_F;
-
-    if(opt_.bm_mode == mode_t::Operation)
-    {
-        std::cout << "\tThroughput: " << opt_.num_ops / ((float)elapsed / 1000)
-                  << " ops/s" << std::endl;
-        std::cout << "\tFalse access rate: " << (float)op_num_f * 100.0 / opt_.num_ops << "%" <<std::endl;
-    }
-    else
-    {
-        // Number of operations done while benchmarking
-        uint64_t op_num = 0;
-        for(auto &lc: local_stats)
-            op_num += lc.operation_count;
-        std::cout << "\tThroughput: " << op_num / ((float)elapsed / 1000)
-                  << " ops/s" << std::endl;
-        std::cout << "\tFalse access rate: " << ((float)op_num_f * 100.0 / op_num) << "%" <<std::endl;
-    }
- 
-    if (opt_.enable_pcm)
-    {
-        std::cout << "PCM Metrics:"
-                  << "\n"
-                  << "\tL3 misses: " << getL3CacheMisses(*before_sstate, *after_sstate) << "\n"
-                  << "\tDRAM Reads (bytes): " << getBytesReadFromMC(*before_sstate, *after_sstate) << "\n"
-                  << "\tDRAM Writes (bytes): " << getBytesWrittenToMC(*before_sstate, *after_sstate) << "\n"
-                  << "\tNVM Reads (bytes): " << getBytesReadFromPMM(*before_sstate, *after_sstate) << "\n"
-                  << "\tNVM Writes (bytes): " << getBytesWrittenToPMM(*before_sstate, *after_sstate) << std::endl;
-    }
-
-    std::cout << "Samples:" << std::endl;
-    std::adjacent_difference(global_stats.begin(), global_stats.end(), global_stats.begin(),
-                             [](const stats_t& x, const stats_t& y) {
-                                 stats_t s;
-                                 s.operation_count = x.operation_count - y.operation_count;
-                                 return s;
-                             });
-
-    for (auto s : global_stats)
-        std::cout << "\t" << s.operation_count << std::endl;
-
-    if(opt_.latency_sampling > 0.0)
-    {
-        std::vector<uint64_t> global_latencies;
-        for(auto& v : local_stats)
-            for(unsigned int i=0; i<v.times.size(); i=i+2)
-                global_latencies.push_back(std::chrono::nanoseconds(v.times[i+1]-v.times[i]).count());
-
-        std::sort(global_latencies.begin(), global_latencies.end());
-        auto observed = global_latencies.size();
-        std::cout << "Latencies (" << observed << " operations observed):\n"
-                  << "\tmin: " << global_latencies[0] << '\n'
-                  << "\t50%: " << global_latencies[0.5*observed] << '\n'
-                  << "\t90%: " << global_latencies[0.9*observed] << '\n'
-                  << "\t99%: " << global_latencies[0.99*observed] << '\n'
-                  << "\t99.9%: " << global_latencies[0.999*observed] << '\n'
-                  << "\t99.99%: " << global_latencies[0.9999*observed] << '\n'
-                  << "\t99.999%: " << global_latencies[0.99999*observed] << '\n'
-                  << "\tmax: " << global_latencies[observed-1] << std::endl;
-    }
-}
-
-bool benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value_out, char *values_out)
-{
-    bool r;
-    switch (operation)
-    {
-        case operation_t::READ:
-        {
-            r = tree_->find(key_ptr, key_generator_->size(), value_out);
-            assert(r);
-            break;
-        }
-
-        case operation_t::INSERT:
-        {
-            // Generate random value
-            auto value_ptr = value_generator_.next();
-            r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-            assert(r);
-            break;
-        }
-
-        case operation_t::UPDATE:
-        {
-            // Generate random value
-            auto value_ptr = value_generator_.next();
-            r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-            assert(r);
-            break;
-        }
-
-        case operation_t::REMOVE:
-        {
-            // TODO: Randomly deleting keys will cause false read,update and scan
-            r = tree_->remove(key_ptr, key_generator_->size());
-            assert(r);
-            break;
-        }
-
-        case operation_t::SCAN:
-        {
-            r = static_cast<bool>(tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out));
-            assert(r);
-            break;
-        }
-
-        default:
-            std::cout << "Error: unknown operation!" << std::endl;
-            exit(0);
-            break;
-    }
-    return r;
-}
 
 } // namespace PiBench
 
 namespace std
 {
-std::ostream& operator<<(std::ostream& os, const PiBench::distribution_t& dist)
-{
-    switch (dist)
+    std::ostream& operator<<(std::ostream& os, const PiBench::distribution_t& dist)
     {
-    case PiBench::distribution_t::UNIFORM:
-        return os << "UNIFORM";
-        break;
-    case PiBench::distribution_t::SELFSIMILAR:
-        return os << "SELFSIMILAR";
-        break;
-    case PiBench::distribution_t::ZIPFIAN:
-        return os << "ZIPFIAN";
-        break;
-    default:
-        return os << static_cast<uint8_t>(dist);
+        switch (dist)
+        {
+            case PiBench::distribution_t::UNIFORM:
+                return os << "UNIFORM";
+                break;
+            case PiBench::distribution_t::SELFSIMILAR:
+                return os << "SELFSIMILAR";
+                break;
+            case PiBench::distribution_t::ZIPFIAN:
+                return os << "ZIPFIAN";
+                break;
+            default:
+                return os << static_cast<uint8_t>(dist);
+        }
     }
-}
 
-std::ostream& operator<<(std::ostream& os, const PiBench::options_t& opt)
-{
-    os << "Benchmark Options:"
-       << "\n"
-       << "\tTarget: " << opt.library_file << "\n"
-       << "\t# Records: " << opt.num_records << "\n"
-       << (opt.bm_mode == PiBench::mode_t::Operation ? "\t# Operations: " : "\t# Running time: ") << (opt.bm_mode == PiBench::mode_t::Operation ? opt.num_ops : opt.time) << "\n"
-       << "\t# Threads: " << opt.num_threads << "\n"
-       << "\tSampling: " << opt.sampling_ms << " ms\n"
-       << "\tLatency: " << opt.latency_sampling << "\n"
-       << "\tKey prefix: " << opt.key_prefix << "\n"
-       << "\tKey size: " << opt.key_size << "\n"
-       << "\tValue size: " << opt.value_size << "\n"
-       << "\tRandom seed: " << opt.rnd_seed << "\n"
-       << "\tKey distribution: " << opt.key_distribution
-       << (opt.key_distribution == PiBench::distribution_t::SELFSIMILAR || opt.key_distribution == PiBench::distribution_t::ZIPFIAN
+    std::ostream& operator<<(std::ostream& os, const PiBench::options_t& opt)
+    {
+        os << "Benchmark Options:"
+           << "\n"
+           << "\tTarget: " << opt.library_file << "\n"
+           << "\t# Records: " << opt.num_records << "\n"
+           << "\t# Threads: " << opt.num_threads << "\n"
+           << (opt.bm_mode == PiBench::mode_t::Operation ? "\t# Operations: " : "\tDuration (s): ") << (opt.bm_mode == PiBench::mode_t::Operation ? opt.num_ops : opt.seconds) << "\n"
+           << "\tSampling: " << opt.sampling_ms << " ms\n"
+           << "\tLatency: " << opt.latency_sampling << "\n"
+           << "\tKey prefix: " << opt.key_prefix << "\n"
+           << "\tKey size: " << opt.key_size << "\n"
+           << "\tValue size: " << opt.value_size << "\n"
+           << "\tRandom seed: " << opt.rnd_seed << "\n"
+           << "\tKey distribution: " << opt.key_distribution
+           << (opt.key_distribution == PiBench::distribution_t::SELFSIMILAR || opt.key_distribution == PiBench::distribution_t::ZIPFIAN
                ? "(" + std::to_string(opt.key_skew) + ")"
                : "")
-       << "\n"
-       << "\tScan size: " << opt.scan_size << "\n"
-       << "\tOperations ratio:\n"
-       << "\t\tRead: " << opt.read_ratio << "\n"
-       << "\t\tInsert: " << opt.insert_ratio << "\n"
-       << "\t\tUpdate: " << opt.update_ratio << "\n"
-       << "\t\tDelete: " << opt.remove_ratio << "\n"
-       << "\t\tScan: " << opt.scan_ratio << "\n"
-       << "\t\tFalse access: " << std::boolalpha << opt.negative_access;
-    return os;
-}
+           << "\n"
+           << "\tScan size: " << opt.scan_size << "\n"
+           << "\tOperations ratio:\n"
+           << "\t\tRead: " << opt.read_ratio << "\n"
+           << "\t\tInsert: " << opt.insert_ratio << "\n"
+           << "\t\tUpdate: " << opt.update_ratio << "\n"
+           << "\t\tDelete: " << opt.remove_ratio << "\n"
+           << "\t\tScan: " << opt.scan_ratio;
+        return os;
+    }
 } // namespace std

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -256,52 +256,7 @@ void benchmark_t::run() noexcept
                             local_stats[tid].times.push_back(std::chrono::high_resolution_clock::now());
                         }
 
-                        switch (op)
-                        {
-                            case operation_t::READ:
-                            {
-                                auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::INSERT:
-                            {
-                                // Generate random value
-                                auto value_ptr = value_generator_.next();
-                                auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::UPDATE:
-                            {
-                                // Generate random value
-                                auto value_ptr = value_generator_.next();
-                                auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::REMOVE:
-                            {
-                                auto r = tree_->remove(key_ptr, key_generator_->size());
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::SCAN:
-                            {
-                                auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
-                                assert(r);
-                                break;
-                            }
-
-                            default:
-                                std::cout << "Error: unknown operation!" << std::endl;
-                                exit(0);
-                                break;
-                        }
+                        run_op(op,key_ptr,value_out,values_out);
 
                         if(measure_latency)
                         {
@@ -419,52 +374,7 @@ void benchmark_t::run() noexcept
                             local_stats[tid].times.push_back(std::chrono::high_resolution_clock::now());
                         }
 
-                        switch (op)
-                        {
-                            case operation_t::READ:
-                            {
-                                auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::INSERT:
-                            {
-                                // Generate random value
-                                auto value_ptr = value_generator_.next();
-                                auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::UPDATE:
-                            {
-                                // Generate random value
-                                auto value_ptr = value_generator_.next();
-                                auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::REMOVE:
-                            {
-                                auto r = tree_->remove(key_ptr, key_generator_->size());
-                                assert(r);
-                                break;
-                            }
-
-                            case operation_t::SCAN:
-                            {
-                                auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
-                                assert(r);
-                                break;
-                            }
-
-                            default:
-                                std::cout << "Error: unknown operation!" << std::endl;
-                                exit(0);
-                                break;
-                        }
+                        run_op(op,key_ptr,value_out,values_out);
 
                         if(measure_latency)
                         {
@@ -546,6 +456,60 @@ void benchmark_t::run() noexcept
                   << "\tmax: " << global_latencies[observed-1] << std::endl;
     }
 }
+
+void benchmark_t::run_op(operation_t operation, const char *key_ptr, char *value_out, char *values_out)
+{
+
+    //std::cout << key_ptr << std::endl;
+
+    switch (operation)
+    {
+        case operation_t::READ:
+        {
+            auto r = tree_->find(key_ptr, key_generator_->size(), value_out);
+            //assert(r);
+            break;
+        }
+
+        case operation_t::INSERT:
+        {
+            // Generate random value
+            auto value_ptr = value_generator_.next();
+            auto r = tree_->insert(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+            //assert(r);
+            break;
+        }
+
+        case operation_t::UPDATE:
+        {
+            // Generate random value
+            auto value_ptr = value_generator_.next();
+            auto r = tree_->update(key_ptr, key_generator_->size(), value_ptr, opt_.value_size);
+            //assert(r);
+            break;
+        }
+
+        case operation_t::REMOVE:
+        {
+            auto r = tree_->remove(key_ptr, key_generator_->size());
+            //assert(r);
+            break;
+        }
+
+        case operation_t::SCAN:
+        {
+            auto r = tree_->scan(key_ptr, key_generator_->size(), opt_.scan_size, values_out);
+            //assert(r);
+            break;
+        }
+
+        default:
+            std::cout << "Error: unknown operation!" << std::endl;
+            exit(0);
+            break;
+    }
+}
+
 } // namespace PiBench
 
 namespace std
@@ -574,7 +538,7 @@ std::ostream& operator<<(std::ostream& os, const PiBench::options_t& opt)
        << "\n"
        << "\tTarget: " << opt.library_file << "\n"
        << "\t# Records: " << opt.num_records << "\n"
-       << (opt.bm_mode ? "\t# Operations:" : "\t# Running time:") << (opt.bm_mode ? opt.num_ops : opt.time) << "\n"
+       << (opt.bm_mode ? "\t# Operations: " : "\t# Running time: ") << (opt.bm_mode ? opt.num_ops : opt.time) << "\n"
        << "\t# Threads: " << opt.num_threads << "\n"
        << "\tSampling: " << opt.sampling_ms << " ms\n"
        << "\tLatency: " << opt.latency_sampling << "\n"

--- a/src/key_generator.cpp
+++ b/src/key_generator.cpp
@@ -4,84 +4,72 @@
 namespace PiBench
 {
 
-thread_local std::default_random_engine key_generator_t::generator_;
-thread_local uint32_t key_generator_t::seed_;
-thread_local char key_generator_t::buf_[KEY_MAX];
-thread_local uint64_t key_generator_t::current_id_ = 1;
+    thread_local std::default_random_engine key_generator_t::generator_;
+    thread_local uint32_t key_generator_t::seed_;
+    thread_local char key_generator_t::buf_[KEY_MAX];
+    thread_local uint64_t key_generator_t::current_id_ = 1;
 
-key_generator_t::key_generator_t(size_t N, size_t size, uint16_t thread_num, bool tid_prefix, const std::string& prefix)
-    : N_(N),
-      size_(size),
-      prefix_(prefix),
-      tid_prefix(tid_prefix)
-{
-    thread_stat = new uint64_t [thread_num]();
-    for(int i=0; i<thread_num; i++)
+    key_generator_t::key_generator_t(size_t N, size_t size, const std::string& prefix)
+            : N_(N),
+              size_(size),
+              prefix_(prefix)
     {
-        thread_stat[i] = 1;
+        memset(buf_, 0, KEY_MAX);
+        memcpy(buf_, prefix_.c_str(), prefix_.size());
     }
-    memset(buf_, 0, KEY_MAX);
-    memcpy(buf_, prefix_.c_str(), prefix_.size());
-}
 
-const char* key_generator_t::next(bool negative_access, bool in_sequence)
-{
-    char* ptr = &buf_[prefix_.size()];
-
-    uint64_t id = in_sequence ? current_id_++ : (negative_access ? next_id() + current_id_ : next_id());
-
-    bits_shift(ptr,id);
-
-    return buf_;
-}
-
-const char* key_generator_t::next(uint8_t tid, bool negative_access, bool in_sequence)
-{
-    // 1 Byte after prefix is tid
-    char *ptr = &buf_[prefix_.size()];
-    memcpy(ptr,&tid,1);
-    ptr = &buf_[prefix_.size()+1];
-
-    uint64_t id = in_sequence ? thread_stat[tid]++ : (negative_access ? next_id(thread_stat[tid] - 1) + thread_stat[tid] : next_id(thread_stat[tid] - 1)) ;
-
-    bits_shift(ptr,id);
-
-    return buf_;
-}
-
-void key_generator_t::bits_shift(char *buf_ptr, uint64_t id)
-{
-    uint64_t hashed_id = utils::multiplicative_hash<uint64_t>(id);
-    if (size_ < sizeof(hashed_id))
+    const char* key_generator_t::next(bool in_sequence)
     {
-        // We want key smaller than 8 Bytes, so discard higher bits.
-        auto bits_to_shift = (sizeof(hashed_id) - size_) << 3;
-
-        // Discard high order bits
-        if (utils::is_big_endian())
+        uint64_t id = -1;
+        if (in_sequence)
         {
-            hashed_id >>= bits_to_shift;
-            hashed_id <<= bits_to_shift;
+            id = current_id_++;
         }
         else
         {
-            hashed_id <<= bits_to_shift;
-            hashed_id >>= bits_to_shift;
+            //if opt_.bm_mode == mode_t::Operation
+            id = next_id();
         }
+        return hash_id(id);
+    }
 
-        memcpy(buf_ptr, &hashed_id, size_); // TODO: check if must change to fit endianess
-    }
-    else
+    const char* key_generator_t::hash_id(uint64_t id)
     {
-        // TODO: change this, otherwise zeroes act as prefix
-        // We want key of at least 8 Bytes, check if we must prepend zeroes
-        auto bytes_to_prepend = size_ - sizeof(hashed_id);
-        if (bytes_to_prepend > 0)
+        char* ptr = &buf_[prefix_.size()];
+
+        uint64_t hashed_id = utils::multiplicative_hash<uint64_t>(id);
+
+        if (size_ < sizeof(hashed_id))
         {
-            memset(buf_ptr, 0, bytes_to_prepend);
-            buf_ptr += bytes_to_prepend;
+            // We want key smaller than 8 Bytes, so discard higher bits.
+            auto bits_to_shift = (sizeof(hashed_id) - size_) << 3;
+
+            // Discard high order bits
+            if (utils::is_big_endian())
+            {
+                hashed_id >>= bits_to_shift;
+                hashed_id <<= bits_to_shift;
+            }
+            else
+            {
+                hashed_id <<= bits_to_shift;
+                hashed_id >>= bits_to_shift;
+            }
+
+            memcpy(ptr, &hashed_id, size_); // TODO: check if must change to fit endianess
         }
-        memcpy(buf_ptr, &hashed_id, sizeof(hashed_id));
+        else
+        {
+            // TODO: change this, otherwise zeroes act as prefix
+            // We want key of at least 8 Bytes, check if we must prepend zeroes
+            auto bytes_to_prepend = size_ - sizeof(hashed_id);
+            if (bytes_to_prepend > 0)
+            {
+                memset(ptr, 0, bytes_to_prepend);
+                ptr += bytes_to_prepend;
+            }
+            memcpy(ptr, &hashed_id, sizeof(hashed_id));
+        }
+        return buf_;
     }
-}
 } // namespace PiBench

--- a/src/key_generator.cpp
+++ b/src/key_generator.cpp
@@ -9,11 +9,12 @@ thread_local uint32_t key_generator_t::seed_;
 thread_local char key_generator_t::buf_[KEY_MAX];
 thread_local uint64_t key_generator_t::current_id_ = 1;
 
-key_generator_t::key_generator_t(size_t N, size_t size, bool benchmark_mode, const std::string& prefix)
+key_generator_t::key_generator_t(size_t N, size_t size, uint16_t thread_num, bool tid_prefix, const std::string& prefix)
     : N_(N),
       size_(size),
       prefix_(prefix),
-      benchmark_mode(benchmark_mode)
+      tid_prefix(tid_prefix),
+      thread_stat(thread_num,1)
 {
     memset(buf_, 0, KEY_MAX);
     memcpy(buf_, prefix_.c_str(), prefix_.size());
@@ -38,7 +39,8 @@ const char* key_generator_t::next(uint8_t tid, uint64_t counter, bool in_sequenc
     memcpy(ptr,&tid,1);
     ptr = &buf_[prefix_.size()+1];
 
-    uint64_t id = in_sequence ? current_id_++ : next_id(counter);
+
+    uint64_t id = in_sequence ? thread_stat[tid]++ : next_id(counter);
     uint64_t hashed_id = utils::multiplicative_hash<uint64_t>(id);
 
     bits_shift(ptr,hashed_id);

--- a/src/key_generator.cpp
+++ b/src/key_generator.cpp
@@ -13,9 +13,13 @@ key_generator_t::key_generator_t(size_t N, size_t size, uint16_t thread_num, boo
     : N_(N),
       size_(size),
       prefix_(prefix),
-      tid_prefix(tid_prefix),
-      thread_stat(thread_num,1)
+      tid_prefix(tid_prefix)
 {
+    thread_stat = new uint64_t [thread_num]();
+    for(int i=0; i<thread_num; i++)
+    {
+        thread_stat[i] = 1;
+    }
     memset(buf_, 0, KEY_MAX);
     memcpy(buf_, prefix_.c_str(), prefix_.size());
 }

--- a/src/key_generator.cpp
+++ b/src/key_generator.cpp
@@ -9,10 +9,11 @@ thread_local uint32_t key_generator_t::seed_;
 thread_local char key_generator_t::buf_[KEY_MAX];
 thread_local uint64_t key_generator_t::current_id_ = 1;
 
-key_generator_t::key_generator_t(size_t N, size_t size, const std::string& prefix)
+key_generator_t::key_generator_t(size_t N, size_t size, bool benchmark_mode, const std::string& prefix)
     : N_(N),
       size_(size),
-      prefix_(prefix)
+      prefix_(prefix),
+      benchmark_mode(benchmark_mode)
 {
     memset(buf_, 0, KEY_MAX);
     memcpy(buf_, prefix_.c_str(), prefix_.size());
@@ -23,6 +24,50 @@ const char* key_generator_t::next(bool in_sequence)
     char* ptr = &buf_[prefix_.size()];
 
     uint64_t id = in_sequence ? current_id_++ : next_id();
+    uint64_t hashed_id = utils::multiplicative_hash<uint64_t>(id);
+
+    if (size_ < sizeof(hashed_id))
+    {
+        // We want key smaller than 8 Bytes, so discard higher bits.
+        auto bits_to_shift = (sizeof(hashed_id) - size_) << 3;
+
+        // Discard high order bits
+        if (utils::is_big_endian())
+        {
+            hashed_id >>= bits_to_shift;
+            hashed_id <<= bits_to_shift;
+        }
+        else
+        {
+            hashed_id <<= bits_to_shift;
+            hashed_id >>= bits_to_shift;
+        }
+
+        memcpy(ptr, &hashed_id, size_); // TODO: check if must change to fit endianess
+    }
+    else
+    {
+        // TODO: change this, otherwise zeroes act as prefix
+        // We want key of at least 8 Bytes, check if we must prepend zeroes
+        auto bytes_to_prepend = size_ - sizeof(hashed_id);
+        if (bytes_to_prepend > 0)
+        {
+            memset(ptr, 0, bytes_to_prepend);
+            ptr += bytes_to_prepend;
+        }
+        memcpy(ptr, &hashed_id, sizeof(hashed_id));
+    }
+    return buf_;
+}
+
+const char* key_generator_t::next(uint8_t tid, uint64_t counter, bool in_sequence)
+{
+    // 1 Byte after prefix is tid
+    char *ptr = &buf_[prefix_.size()];
+    memcpy(ptr,&tid,1);
+    ptr = &buf_[prefix_.size()+1];
+
+    uint64_t id = in_sequence ? current_id_++ : next_id(counter);
     uint64_t hashed_id = utils::multiplicative_hash<uint64_t>(id);
 
     if (size_ < sizeof(hashed_id))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char** argv)
             ("s,scan_ratio", "Ratio of scan operations", cxxopts::value<float>()->default_value(std::to_string(opt.scan_ratio)))
             ("scan_size", "Number of records to be scanned.", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.scan_size)))
             ("negative_access","Generate keys not in the index",cxxopts::value<bool>()->default_value((opt.negative_access ? "true" : "false")))
+            ("negative_access_rate"," Ratio of negative read/update operations",cxxopts::value<float>()->default_value(std::to_string(opt.negative_access_rate)))
             ("sampling_ms", "Sampling window in milliseconds", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.sampling_ms)))
             ("distribution", "Key distribution to use", cxxopts::value<std::string>()->default_value("UNIFORM"))
             ("skew", "Key distribution skew factor to use", cxxopts::value<float>()->default_value(std::to_string(opt.key_skew)))
@@ -198,11 +199,17 @@ int main(int argc, char** argv)
         if (result.count("time"))
             opt.time = result["time"].as<float>();
 
+        //Parse "negative_access_rate"
+        if(result.count("negative_access_rate"))
+            opt.negative_access_rate = result["negative_access_rate"].as<float>();
+
         //Parse "negative_access"
         if(result.count("negative_access"))
+        {
             opt.negative_access = result["negative_access"].as<bool>();
-
-
+            if(!opt.negative_access)
+                opt.negative_access_rate = 0.0;
+        }
     }
     catch (const cxxopts::OptionException& e)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ int main(int argc, char** argv)
             ("d,remove_ratio", "Ratio of remove operations", cxxopts::value<float>()->default_value(std::to_string(opt.remove_ratio)))
             ("s,scan_ratio", "Ratio of scan operations", cxxopts::value<float>()->default_value(std::to_string(opt.scan_ratio)))
             ("scan_size", "Number of records to be scanned.", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.scan_size)))
+            ("false_access","Generate keys not in the index",cxxopts::value<bool>()->default_value((opt.false_access ? "true":"false")))
             ("sampling_ms", "Sampling window in milliseconds", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.sampling_ms)))
             ("distribution", "Key distribution to use", cxxopts::value<std::string>()->default_value("UNIFORM"))
             ("skew", "Key distribution skew factor to use", cxxopts::value<float>()->default_value(std::to_string(opt.key_skew)))
@@ -47,7 +48,7 @@ int main(int argc, char** argv)
             ("pool_size", "Size of persistent pool (in Bytes)", cxxopts::value<uint64_t>()->default_value(std::to_string(tree_opt.pool_size)))
             ("skip_load", "Skip the load phase", cxxopts::value<bool>()->default_value((opt.skip_load ? "true" : "false")))
             ("latency_sampling", "Sample latency of requests", cxxopts::value<float>()->default_value(std::to_string(opt.latency_sampling)))
-            ("m,mode","Benchmark mode",cxxopts::value<bool>()->default_value((opt.bm_mode ? "true":"false")))
+            ("mode","Benchmark mode",cxxopts::value<bool>()->default_value((opt.bm_mode ? "true":"false")))
             ("time","Time PiBench run in time-based mode",cxxopts::value<float>()->default_value(std::to_string(opt.time)))
             ("help", "Print help")
         ;
@@ -185,6 +186,10 @@ int main(int argc, char** argv)
         if (result.count("time"))
             opt.time = result["time"].as<float>();
 
+        //Parse "false_access"
+        if(result.count("false_access"))
+            opt.false_access = result["false_access"].as<bool>();
+
 
     }
     catch (const cxxopts::OptionException& e)
@@ -217,6 +222,12 @@ int main(int argc, char** argv)
         if(opt.num_threads > 256)
         {
             std::cout << "In time-based mode, thread number must be less than 256." <<std::endl;
+            exit(1);
+        }
+
+        if(opt.time <= 0.0)
+        {
+            std::cout << "Benchmark running time must be larger than 0." <<std::endl;
             exit(1);
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,315 +1,75 @@
-#include "tree_api.hpp"
-#include "benchmark.hpp"
-#include "library_loader.hpp"
-#include "cxxopts.hpp"
+#include "key_generator.hpp"
+#include "utils.hpp"
 
-#include <iostream>
-#include <algorithm>
-#include <cstdlib>
-#include <cerrno>
-
-#include <dlfcn.h>
-
-using namespace PiBench;
-
-int main(int argc, char** argv)
+namespace PiBench
 {
-    // Parse command line arguments
-    options_t opt;
-    tree_options_t tree_opt;
-    try
+
+    thread_local std::default_random_engine key_generator_t::generator_;
+    thread_local uint32_t key_generator_t::seed_;
+    thread_local char key_generator_t::buf_[KEY_MAX];
+    thread_local uint64_t key_generator_t::current_id_ = 1;
+
+    key_generator_t::key_generator_t(size_t N, size_t size, const std::string& prefix)
+            : N_(N),
+              size_(size),
+              prefix_(prefix)
     {
-        cxxopts::Options options("PiBench", "Benchmark framework for persistent indexes.");
-        options
-            .positional_help("INPUT")
-            .show_positional_help();
+        memset(buf_, 0, KEY_MAX);
+        memcpy(buf_, prefix_.c_str(), prefix_.size());
+    }
 
-        options.add_options()
-            ("input", "Absolute path to library file", cxxopts::value<std::string>())
-            ("n,records", "Number of records to load", cxxopts::value<uint64_t>()->default_value(std::to_string(opt.num_records)))
-            ("p,operations", "Number of operations to execute", cxxopts::value<uint64_t>()->default_value(std::to_string(opt.num_ops)))
-            ("t,threads", "Number of threads to use", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.num_threads)))
-            ("f,key_prefix", "Prefix string prepended to every key", cxxopts::value<std::string>()->default_value("\"" + opt.key_prefix + "\""))
-            ("k,key_size", "Size of keys in Bytes (without prefix)", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.key_size)))
-            ("v,value_size", "Size of values in Bytes", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.value_size)))
-            ("r,read_ratio", "Ratio of read operations", cxxopts::value<float>()->default_value(std::to_string(opt.read_ratio)))
-            ("i,insert_ratio", "Ratio of insert operations", cxxopts::value<float>()->default_value(std::to_string(opt.insert_ratio)))
-            ("u,update_ratio", "Ratio of update operations", cxxopts::value<float>()->default_value(std::to_string(opt.update_ratio)))
-            ("d,remove_ratio", "Ratio of remove operations", cxxopts::value<float>()->default_value(std::to_string(opt.remove_ratio)))
-            ("s,scan_ratio", "Ratio of scan operations", cxxopts::value<float>()->default_value(std::to_string(opt.scan_ratio)))
-            ("scan_size", "Number of records to be scanned.", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.scan_size)))
-            ("negative_access","Generate keys not in the index",cxxopts::value<bool>()->default_value((opt.negative_access ? "true" : "false")))
-            ("negative_access_rate"," Ratio of negative read/update operations",cxxopts::value<float>()->default_value(std::to_string(opt.negative_access_rate)))
-            ("sampling_ms", "Sampling window in milliseconds", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.sampling_ms)))
-            ("distribution", "Key distribution to use", cxxopts::value<std::string>()->default_value("UNIFORM"))
-            ("skew", "Key distribution skew factor to use", cxxopts::value<float>()->default_value(std::to_string(opt.key_skew)))
-            ("seed", "Seed for random generators", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.rnd_seed)))
-            ("pcm", "Turn on Intel PCM", cxxopts::value<bool>()->default_value((opt.enable_pcm ? "true" : "false")))
-            ("pool_path", "Path to persistent pool", cxxopts::value<std::string>()->default_value("\"" + tree_opt.pool_path + "\""))
-            ("pool_size", "Size of persistent pool (in Bytes)", cxxopts::value<uint64_t>()->default_value(std::to_string(tree_opt.pool_size)))
-            ("skip_load", "Skip the load phase", cxxopts::value<bool>()->default_value((opt.skip_load ? "true" : "false")))
-            ("latency_sampling", "Sample latency of requests", cxxopts::value<float>()->default_value(std::to_string(opt.latency_sampling)))
-            ("mode","Benchmark mode",cxxopts::value<std::string>()->default_value("operation"))
-            ("time","Time PiBench run in time-based mode",cxxopts::value<float>()->default_value(std::to_string(opt.time)))
-            ("help", "Print help")
-        ;
-
-        options.parse_positional({"input"});
-
-        auto result = options.parse(argc, argv);
-        if (result.count("help"))
+    const char* key_generator_t::next(bool in_sequence)
+    {
+        uint64_t id = -1;
+        if (in_sequence)
         {
-            std::cout << options.help() << std::endl;
-            exit(0);
-        }
-
-        if (result.count("pcm"))
-        {
-            opt.enable_pcm = result["pcm"].as<bool>();
-        }
-
-        if (result.count("skip_load"))
-        {
-            opt.skip_load = result["skip_load"].as<bool>();
-        }
-
-        if (result.count("latency_sampling"))
-        {
-            opt.latency_sampling = result["latency_sampling"].as<float>();
-        }
-
-        if (result.count("input"))
-        {
-            opt.library_file = result["input"].as<std::string>();
+            id = current_id_++;
         }
         else
         {
-            std::cout << "Missing 'input' argument." << std::endl;
-            std::cout << options.help() << std::endl;
-            exit(0);
+            //if opt_.bm_mode == mode_t::Operation
+            id = next_id();
         }
+        return hash_id(id);
+    }
 
-        // Parse "num_records"
-        if (result.count("records"))
-            opt.num_records = result["records"].as<uint64_t>();
+    const char* key_generator_t::hash_id(uint64_t id)
+    {
+        char* ptr = &buf_[prefix_.size()];
 
-        // Parse "num_operations"
-        if (result.count("operations"))
-            opt.num_ops = result["operations"].as<uint64_t>();
+        uint64_t hashed_id = utils::multiplicative_hash<uint64_t>(id);
 
-        // Parse "num_threads"
-        if (result.count("threads"))
-            opt.num_threads = result["threads"].as<uint32_t>();
-
-        // Parse "sampling_ms"
-        if (result.count("sampling_ms"))
-            opt.sampling_ms = result["sampling_ms"].as<uint32_t>();
-
-        // Parse "key_prefix"
-        if (result.count("key_prefix"))
-            opt.key_prefix = result["key_prefix"].as<std::string>();
-
-        // Parse "key_size"
-        if (result.count("key_size"))
-            opt.key_size = result["key_size"].as<uint32_t>();
-
-        // Parse "value_size"
-        if (result.count("value_size"))
-            opt.value_size = result["value_size"].as<uint32_t>();
-
-        // Parse "ops_ratio"
-        if (result.count("read_ratio"))
-            opt.read_ratio = result["read_ratio"].as<float>();
-
-        if (result.count("insert_ratio"))
-            opt.insert_ratio = result["insert_ratio"].as<float>();
-
-        if (result.count("update_ratio"))
-            opt.update_ratio = result["update_ratio"].as<float>();
-
-        if (result.count("remove_ratio"))
-            opt.remove_ratio = result["remove_ratio"].as<float>();
-
-        if (result.count("scan_ratio"))
-            opt.scan_ratio = result["scan_ratio"].as<float>();
-
-        // Parse 'scan_size'.
-        if (result.count("scan_size"))
-            opt.scan_size = result["scan_size"].as<uint32_t>();
-
-        // Parse 'key_distribution'
-        if(result.count("distribution"))
+        if (size_ < sizeof(hashed_id))
         {
-            std::string dist = result["distribution"].as<std::string>();
-            std::transform(dist.begin(), dist.end(), dist.begin(), ::tolower);
-            if(dist.compare("uniform") == 0)
-                opt.key_distribution = distribution_t::UNIFORM;
-            else if(dist.compare("selfsimilar") == 0)
-                opt.key_distribution = distribution_t::SELFSIMILAR;
-            else if(dist.compare("zipfian") == 0)
+            // We want key smaller than 8 Bytes, so discard higher bits.
+            auto bits_to_shift = (sizeof(hashed_id) - size_) << 3;
+
+            // Discard high order bits
+            if (utils::is_big_endian())
             {
-                std::cout
-                    << "WARNING: initializing ZIPFIAN generator might take time."
-                    << std::endl;
-                opt.key_distribution = distribution_t::ZIPFIAN;
+                hashed_id >>= bits_to_shift;
+                hashed_id <<= bits_to_shift;
             }
             else
             {
-                std::cout << "Invalid key distribution, must be one of "
-                << "[UNIFORM | SELFSIMILAR | ZIPFIAN], but is " << dist << std::endl;
-                exit(1);
+                hashed_id <<= bits_to_shift;
+                hashed_id >>= bits_to_shift;
             }
+
+            memcpy(ptr, &hashed_id, size_); // TODO: check if must change to fit endianess
         }
-
-        // Parse 'key_skew'
-        if (result.count("skew"))
-            opt.key_skew = result["skew"].as<float>();
-
-        // Parse 'rnd_seed'
-        if (result.count("seed"))
+        else
         {
-            opt.rnd_seed = result["seed"].as<uint32_t>();
-        }
-
-        // Parse "pool_path"
-        if (result.count("pool_path"))
-            tree_opt.pool_path = result["pool_path"].as<std::string>();
-
-        // Parse "pool_size"
-        if (result.count("pool_size"))
-            tree_opt.pool_size = result["pool_size"].as<uint64_t>();
-
-        // Parse "mode"
-        if (result.count("mode"))
-        {
-            std::string mode = result["mode"].as<std::string>();
-            std::transform(mode.begin(),mode.end(),mode.begin(),::tolower);
-            if(mode.compare("operation") == 0)
-                opt.bm_mode = PiBench::mode_t::Operation;
-            else if(mode.compare("time") == 0)
-                opt.bm_mode = PiBench::mode_t::Time;
-            else
+            // TODO: change this, otherwise zeroes act as prefix
+            // We want key of at least 8 Bytes, check if we must prepend zeroes
+            auto bytes_to_prepend = size_ - sizeof(hashed_id);
+            if (bytes_to_prepend > 0)
             {
-                std::cout << "Mode must be one of [operation | time]" << std::endl;
-                exit(1);
+                memset(ptr, 0, bytes_to_prepend);
+                ptr += bytes_to_prepend;
             }
+            memcpy(ptr, &hashed_id, sizeof(hashed_id));
         }
-
-        // Parse "time"
-        if (result.count("time"))
-            opt.time = result["time"].as<float>();
-
-        //Parse "negative_access_rate"
-        if(result.count("negative_access_rate"))
-            opt.negative_access_rate = result["negative_access_rate"].as<float>();
-
-        //Parse "negative_access"
-        if(result.count("negative_access"))
-        {
-            opt.negative_access = result["negative_access"].as<bool>();
-            if(!opt.negative_access)
-                opt.negative_access_rate = 0.0;
-        }
+        return buf_;
     }
-    catch (const cxxopts::OptionException& e)
-    {
-        std::cout << "Error parsing options: " << e.what() << std::endl;
-        exit(1);
-    }
-
-    // Sanitize options
-    if(opt.bm_mode == PiBench::mode_t::Operation)
-    {
-        if(opt.key_prefix.size() + opt.key_size > key_generator_t::KEY_MAX)
-        {
-            std::cout << "Total key size cannot be greater than " << key_generator_t::KEY_MAX
-                      << ", but is " << opt.key_prefix.size() + opt.key_size << std::endl;
-            exit(1);
-        }
-    }
-    else
-    {
-        // 1 is for 256 threads
-        if(opt.key_prefix.size() + opt.key_size + 1 > key_generator_t::KEY_MAX)
-        {
-            std::cout << "Total key size cannot be greater than " << key_generator_t::KEY_MAX
-                      << ", but is " << opt.key_prefix.size() + opt.key_size +1 << std::endl;
-            exit(1);
-        }
-
-        // TODO: in time based mode, only support max of 256 threads
-        if(opt.num_threads > 256)
-        {
-            std::cout << "In time-based mode, thread number must be less than 256." <<std::endl;
-            exit(1);
-        }
-
-        if(opt.time <= 0.0)
-        {
-            std::cout << "Benchmark running time must be larger than 0." <<std::endl;
-            exit(1);
-        }
-    }
-
-    if(opt.value_size > value_generator_t::VALUE_MAX)
-    {
-        std::cout << "Total value size cannot be greater than " << value_generator_t::VALUE_MAX
-            << ", but is " << opt.value_size << std::endl;
-        exit(1);
-    }
-
-    auto sum = opt.read_ratio+opt.insert_ratio+opt.update_ratio+opt.remove_ratio+opt.scan_ratio;
-    if (sum != 1.0)
-    {
-        std::cout << "Sum of ratios should be 1.0 but is " << sum << std::endl;
-        exit(1);
-    }
-
-    if(opt.scan_size < 1 || opt.scan_size > benchmark_t::MAX_SCAN)
-    {
-        std::cout << "Scan size must be in the range [1," << value_generator_t::VALUE_MAX
-            << "], but is " << opt.scan_size << std::endl;
-        exit(1);
-    }
-
-    if(opt.key_distribution == distribution_t::SELFSIMILAR && (opt.key_skew < 0.0 || opt.key_skew > 0.5))
-    {
-        std::cout << "Skew factor must be in the range [0 , 0.5]." << std::endl;
-        exit(1);
-    }
-
-    if(opt.key_distribution == distribution_t::ZIPFIAN && (opt.key_skew < 0.0 || opt.key_skew > 1.0))
-    {
-        std::cout << "Skew factor must be in the range [0.0 , 1.0]." << std::endl;
-        exit(1);
-    }
-
-    if((opt.latency_sampling < 0.0 || opt.latency_sampling > 1.0))
-    {
-        std::cout << "Latency sampling must be in the range [0.0 , 1.0]." << std::endl;
-        exit(1);
-    }
-
-    // Print env and options
-    print_environment();
-    std::cout << opt << std::endl;
-
-    tree_opt.key_size = opt.key_prefix.size() + opt.key_size + (opt.bm_mode == PiBench::mode_t::Time ? 1:0);
-    tree_opt.value_size = opt.value_size;
-    tree_opt.num_threads = opt.num_threads;
-
-    library_loader_t lib(opt.library_file);
-    tree_api* tree = lib.create_tree(tree_opt);
-    if(tree == nullptr)
-    {
-        std::cout << "Error instantiating tree." << std::endl;
-        exit(1);
-    }
-
-    benchmark_t bench(tree, opt);
-    bench.load();
-    bench.run();
-
-    delete tree;
-    return 0;
-}
+} // namespace PiBench

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv)
             ("d,remove_ratio", "Ratio of remove operations", cxxopts::value<float>()->default_value(std::to_string(opt.remove_ratio)))
             ("s,scan_ratio", "Ratio of scan operations", cxxopts::value<float>()->default_value(std::to_string(opt.scan_ratio)))
             ("scan_size", "Number of records to be scanned.", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.scan_size)))
-            ("false_access","Generate keys not in the index",cxxopts::value<bool>()->default_value((opt.false_access ? "true":"false")))
+            ("negative_access","Generate keys not in the index",cxxopts::value<bool>()->default_value((opt.negative_access ? "true" : "false")))
             ("sampling_ms", "Sampling window in milliseconds", cxxopts::value<uint32_t>()->default_value(std::to_string(opt.sampling_ms)))
             ("distribution", "Key distribution to use", cxxopts::value<std::string>()->default_value("UNIFORM"))
             ("skew", "Key distribution skew factor to use", cxxopts::value<float>()->default_value(std::to_string(opt.key_skew)))
@@ -198,9 +198,9 @@ int main(int argc, char** argv)
         if (result.count("time"))
             opt.time = result["time"].as<float>();
 
-        //Parse "false_access"
-        if(result.count("false_access"))
-            opt.false_access = result["false_access"].as<bool>();
+        //Parse "negative_access"
+        if(result.count("negative_access"))
+            opt.negative_access = result["negative_access"].as<bool>();
 
 
     }


### PR DESCRIPTION
This branch changes the way keys are generated. 
Suppose there are N threads. Thread M will start to generate its key from `M * std::numeric_limits<uint64_t>::max() / N`.

**List of main changes:**

1. Add a cur_id_table array and a cur_id_start array to key_generator and current_id is not needed.
2. In operation-based mode., keys are now generated the same way as time-based mode.
3. Use only a `(0,std::numeric_limits<uint64_t>::max())`distribution and calculate mod to generate random number within range.

**Todos:**
1. Multithreaded benchmark can cause a very small portion of negative read/update ops if there are insert ops in the run phase. As the cur_id_table is doing a ++ before the key is inserted into the index.
2. OpenMP's parallel for `omp for schedule()` can not make sure the exact number of insertions for each thread in the load phase if num_records can not divide evenly to num_thread.
3. Implementation of a right delete benchmark.
4. Use a faster random number generator(eg. [foedus](https://github.com/HewlettPackard/foedus_code/tree/master/foedus-core/include/foedus/assorted))